### PR TITLE
Phase 1: Project scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# Xcode
+xcuserdata/
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+.build/
+
+# Carthage
+Carthage/Build/
+
+# fastlane
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Environments
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Build output
+build/
+
+# Claude Code
+.claude/worktrees/
+
+# Data
+.DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# MacVitals
+
+macOS menu bar app for monitoring system vitals (CPU, Memory, Storage, Battery, Thermals).
+
+## Tech Stack
+
+- Swift 6, SwiftUI, macOS 15+
+- Xcode project (not SPM-based app target)
+- No SPM dependencies for MVP
+- Non-sandboxed (needed for SMC/process enumeration)
+
+## Architecture
+
+- MVVM with @Observable ViewModel annotated @MainActor
+- Singleton services: SystemMonitor (timer orchestrator), collectors (CPU, Memory, Storage, Battery, Thermal, Process)
+- UserPreferences: @MainActor ObservableObject singleton using UserDefaults
+- Menu bar app via NSPopover (AppDelegate manages status item)
+- WindowManager handles settings window
+- Launch at login via SMAppService (native macOS 13+)
+
+## Project Structure
+
+```
+MacVitals/MacVitals/          # Source root
+  Models/                     # Data models (CPUInfo, MemoryInfo, etc.)
+  Services/                   # System data collectors + orchestrator
+  ViewModels/                 # @Observable view models
+  Views/                      # SwiftUI views (popover, sections, settings)
+  Utilities/                  # Preferences, formatters, constants
+MacVitals/MacVitalsTests/     # Unit tests
+```
+
+## Conventions
+
+- Conventional commits: type(scope): subject
+- English only for code, comments, docs
+- Use `rg` not `grep`, `fd` not `find`
+- Self-documenting code over comments
+
+## Build
+
+```sh
+xcodebuild -project MacVitals/MacVitals.xcodeproj -scheme MacVitals -configuration Debug build
+```
+
+## Test
+
+```sh
+xcodebuild -project MacVitals/MacVitals.xcodeproj -scheme MacVitals -configuration Debug test
+```

--- a/MacVitals/MacVitals.xcodeproj/project.pbxproj
+++ b/MacVitals/MacVitals.xcodeproj/project.pbxproj
@@ -1,0 +1,450 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXContainerItemProxy section */
+		TEST_CONTAINER_PROXY /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = PROJECT /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = APP_TARGET;
+			remoteInfo = MacVitals;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		APP_PRODUCT /* MacVitals.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MacVitals.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		TEST_PRODUCT /* MacVitalsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MacVitalsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		EXCEPTION_SET /* Exceptions for "MacVitals/MacVitals" folder in "MacVitals" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = APP_TARGET /* MacVitals */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		SOURCE_ROOT /* MacVitals/MacVitals */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				EXCEPTION_SET /* Exceptions for "MacVitals/MacVitals" folder in "MacVitals" target */,
+			);
+			path = MacVitals;
+			sourceTree = "<group>";
+		};
+		TEST_SOURCE_ROOT /* MacVitalsTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = MacVitalsTests;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		FRAMEWORKS_PHASE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		TEST_FRAMEWORKS_PHASE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		PRODUCTS_GROUP /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				APP_PRODUCT /* MacVitals.app */,
+				TEST_PRODUCT /* MacVitalsTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		ROOT_GROUP = {
+			isa = PBXGroup;
+			children = (
+				SOURCE_ROOT /* MacVitals/MacVitals */,
+				TEST_SOURCE_ROOT /* MacVitalsTests */,
+				PRODUCTS_GROUP /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		APP_TARGET /* MacVitals */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CONFIG_LIST /* Build configuration list for PBXNativeTarget "MacVitals" */;
+			buildPhases = (
+				SOURCES_PHASE /* Sources */,
+				FRAMEWORKS_PHASE /* Frameworks */,
+				RESOURCES_PHASE /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				SOURCE_ROOT /* MacVitals/MacVitals */,
+			);
+			name = MacVitals;
+			productName = MacVitals;
+			productReference = APP_PRODUCT /* MacVitals.app */;
+			productType = "com.apple.product-type.application";
+		};
+		TEST_TARGET /* MacVitalsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = TEST_CONFIG_LIST /* Build configuration list for PBXNativeTarget "MacVitalsTests" */;
+			buildPhases = (
+				TEST_SOURCES_PHASE /* Sources */,
+				TEST_FRAMEWORKS_PHASE /* Frameworks */,
+				TEST_RESOURCES_PHASE /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				TEST_TARGET_DEPENDENCY /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				TEST_SOURCE_ROOT /* MacVitalsTests */,
+			);
+			name = MacVitalsTests;
+			productName = MacVitalsTests;
+			productReference = TEST_PRODUCT /* MacVitalsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		PROJECT /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1600;
+				LastUpgradeCheck = 2610;
+			};
+			buildConfigurationList = PROJECT_CONFIG_LIST /* Build configuration list for PBXProject "MacVitals" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = ROOT_GROUP;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = PRODUCTS_GROUP /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				APP_TARGET /* MacVitals */,
+				TEST_TARGET /* MacVitalsTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		RESOURCES_PHASE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		TEST_RESOURCES_PHASE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		SOURCES_PHASE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		TEST_SOURCES_PHASE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		TEST_TARGET_DEPENDENCY /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = APP_TARGET /* MacVitals */;
+			targetProxy = TEST_CONTAINER_PROXY /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		DEBUG_CONFIG /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = M623SY9DG8;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 6.0;
+			};
+			name = Debug;
+		};
+		RELEASE_CONFIG /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = M623SY9DG8;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Release;
+		};
+		TARGET_DEBUG_CONFIG /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = MacVitals/MacVitals.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				ENABLE_APP_SANDBOX = NO;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = MacVitals/Info.plist;
+				INFOPLIST_KEY_LSUIElement = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.olivierwinkler.MacVitals;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Debug;
+		};
+		TARGET_RELEASE_CONFIG /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = MacVitals/MacVitals.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				ENABLE_APP_SANDBOX = NO;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = MacVitals/Info.plist;
+				INFOPLIST_KEY_LSUIElement = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.olivierwinkler.MacVitals;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Release;
+		};
+		TEST_DEBUG_CONFIG /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.olivierwinkler.MacVitalsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MacVitals.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/MacVitals";
+			};
+			name = Debug;
+		};
+		TEST_RELEASE_CONFIG /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.olivierwinkler.MacVitalsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MacVitals.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/MacVitals";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		CONFIG_LIST /* Build configuration list for PBXNativeTarget "MacVitals" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				TARGET_DEBUG_CONFIG /* Debug */,
+				TARGET_RELEASE_CONFIG /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		PROJECT_CONFIG_LIST /* Build configuration list for PBXProject "MacVitals" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DEBUG_CONFIG /* Debug */,
+				RELEASE_CONFIG /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		TEST_CONFIG_LIST /* Build configuration list for PBXNativeTarget "MacVitalsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				TEST_DEBUG_CONFIG /* Debug */,
+				TEST_RELEASE_CONFIG /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = PROJECT /* Project object */;
+}

--- a/MacVitals/MacVitals.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/MacVitals/MacVitals.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/MacVitals/MacVitals/AppDelegate.swift
+++ b/MacVitals/MacVitals/AppDelegate.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+import AppKit
+
+@MainActor
+class AppDelegate: NSObject, NSApplicationDelegate {
+    private var statusItem: NSStatusItem?
+    private var popover: NSPopover?
+    private var isQuittingFromMenu = false
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+
+        if let button = statusItem?.button {
+            button.image = NSImage(
+                systemSymbolName: "gauge.with.dots.needle.bottom.50percent",
+                accessibilityDescription: "MacVitals"
+            )
+            button.action = #selector(statusItemClicked)
+            button.target = self
+            button.sendAction(on: [.leftMouseUp, .rightMouseUp])
+        }
+
+        popover = NSPopover()
+        popover?.contentSize = NSSize(width: 420, height: 550)
+        popover?.behavior = .transient
+        popover?.contentViewController = NSHostingController(
+            rootView: MenuBarView()
+                .environmentObject(UserPreferences.shared)
+        )
+
+        NSApp.setActivationPolicy(.accessory)
+
+        SystemMonitor.shared.start()
+    }
+
+    @objc private func statusItemClicked() {
+        guard let event = NSApp.currentEvent else { return }
+        guard let button = statusItem?.button else { return }
+
+        if event.type == .rightMouseUp {
+            let menu = NSMenu()
+            menu.addItem(
+                NSMenuItem(
+                    title: "Settings...",
+                    action: #selector(openSettings),
+                    keyEquivalent: ","
+                )
+            )
+            menu.addItem(NSMenuItem.separator())
+            menu.addItem(
+                NSMenuItem(
+                    title: "Quit MacVitals",
+                    action: #selector(quitApp),
+                    keyEquivalent: "q"
+                )
+            )
+
+            statusItem?.menu = menu
+            button.performClick(nil)
+            statusItem?.menu = nil
+        } else {
+            togglePopover()
+        }
+    }
+
+    private func togglePopover() {
+        guard let popover = popover, let button = statusItem?.button else { return }
+        if popover.isShown {
+            popover.performClose(nil)
+        } else {
+            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+            NSApp.activate(ignoringOtherApps: true)
+        }
+    }
+
+    @objc private func openSettings() {
+        WindowManager.shared.openSettingsWindow()
+    }
+
+    @objc private func quitApp() {
+        isQuittingFromMenu = true
+        NSApp.terminate(nil)
+    }
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        if isQuittingFromMenu {
+            return .terminateNow
+        }
+
+        let alert = NSAlert()
+        alert.messageText = "Quit MacVitals?"
+        alert.informativeText =
+            "MacVitals runs in the menu bar to monitor your system. Use the menu bar icon's right-click menu to quit."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Keep Running")
+        alert.addButton(withTitle: "Quit")
+
+        let response = alert.runModal()
+        if response == .alertSecondButtonReturn {
+            return .terminateNow
+        }
+        return .terminateCancel
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        SystemMonitor.shared.stop()
+    }
+}

--- a/MacVitals/MacVitals/Info.plist
+++ b/MacVitals/MacVitals/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>LSUIElement</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2026 Olivier Winkler. All rights reserved.</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.utilities</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/MacVitals/MacVitals/MacVitals.entitlements
+++ b/MacVitals/MacVitals/MacVitals.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<false/>
+</dict>
+</plist>

--- a/MacVitals/MacVitals/MacVitalsApp.swift
+++ b/MacVitals/MacVitals/MacVitalsApp.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+@main
+struct MacVitalsApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    var body: some Scene {
+        Settings {
+            EmptyView()
+        }
+    }
+}

--- a/MacVitals/MacVitals/Media.xcassets/AccentColor.colorset/Contents.json
+++ b/MacVitals/MacVitals/Media.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MacVitals/MacVitals/Media.xcassets/AppIcon.appiconset/Contents.json
+++ b/MacVitals/MacVitals/Media.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MacVitals/MacVitals/Media.xcassets/Contents.json
+++ b/MacVitals/MacVitals/Media.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MacVitals/MacVitals/Models/BatteryInfo.swift
+++ b/MacVitals/MacVitals/Models/BatteryInfo.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+struct BatteryInfo {
+    let level: Double
+    let health: Double
+    let cycleCount: Int
+    let isCharging: Bool
+    let isPluggedIn: Bool
+    let timeRemaining: TimeInterval?
+    let temperature: Double?
+
+    static let empty = BatteryInfo(
+        level: 0,
+        health: 0,
+        cycleCount: 0,
+        isCharging: false,
+        isPluggedIn: false,
+        timeRemaining: nil,
+        temperature: nil
+    )
+}

--- a/MacVitals/MacVitals/Models/CPUInfo.swift
+++ b/MacVitals/MacVitals/Models/CPUInfo.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct CPUInfo {
+    let totalUsage: Double
+    let userUsage: Double
+    let systemUsage: Double
+    let coreUsages: [Double]
+    let topProcesses: [ProcessSnapshot]
+
+    static let empty = CPUInfo(
+        totalUsage: 0,
+        userUsage: 0,
+        systemUsage: 0,
+        coreUsages: [],
+        topProcesses: []
+    )
+}

--- a/MacVitals/MacVitals/Models/MemoryInfo.swift
+++ b/MacVitals/MacVitals/Models/MemoryInfo.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+enum MemoryPressure: String {
+    case nominal = "Nominal"
+    case warning = "Warning"
+    case critical = "Critical"
+}
+
+struct MemoryInfo {
+    let total: UInt64
+    let used: UInt64
+    let active: UInt64
+    let wired: UInt64
+    let compressed: UInt64
+    let available: UInt64
+    let pressure: MemoryPressure
+    let topProcesses: [ProcessSnapshot]
+
+    var usagePercentage: Double {
+        guard total > 0 else { return 0 }
+        return Double(used) / Double(total) * 100
+    }
+
+    static let empty = MemoryInfo(
+        total: 0,
+        used: 0,
+        active: 0,
+        wired: 0,
+        compressed: 0,
+        available: 0,
+        pressure: .nominal,
+        topProcesses: []
+    )
+}

--- a/MacVitals/MacVitals/Models/ProcessSnapshot.swift
+++ b/MacVitals/MacVitals/Models/ProcessSnapshot.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+struct ProcessSnapshot: Identifiable {
+    let pid: Int32
+    let name: String
+    let cpuUsage: Double
+    let memoryBytes: UInt64
+
+    var id: Int32 { pid }
+}

--- a/MacVitals/MacVitals/Models/StorageInfo.swift
+++ b/MacVitals/MacVitals/Models/StorageInfo.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct StorageInfo {
+    let total: UInt64
+    let used: UInt64
+    let free: UInt64
+    let readBytesPerSec: UInt64
+    let writeBytesPerSec: UInt64
+
+    var usagePercentage: Double {
+        guard total > 0 else { return 0 }
+        return Double(used) / Double(total) * 100
+    }
+
+    static let empty = StorageInfo(
+        total: 0,
+        used: 0,
+        free: 0,
+        readBytesPerSec: 0,
+        writeBytesPerSec: 0
+    )
+}

--- a/MacVitals/MacVitals/Models/SystemSnapshot.swift
+++ b/MacVitals/MacVitals/Models/SystemSnapshot.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct SystemSnapshot {
+    let timestamp: Date
+    let cpu: CPUInfo
+    let memory: MemoryInfo
+    let storage: StorageInfo
+    let battery: BatteryInfo?
+    let thermal: ThermalInfo
+    let uptime: TimeInterval
+}

--- a/MacVitals/MacVitals/Models/ThermalInfo.swift
+++ b/MacVitals/MacVitals/Models/ThermalInfo.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct FanInfo: Identifiable {
+    let id: Int
+    let currentRPM: Int
+    let minRPM: Int
+    let maxRPM: Int
+}
+
+struct ThermalInfo {
+    let cpuTemperature: Double?
+    let gpuTemperature: Double?
+    let fans: [FanInfo]
+
+    static let empty = ThermalInfo(
+        cpuTemperature: nil,
+        gpuTemperature: nil,
+        fans: []
+    )
+}

--- a/MacVitals/MacVitals/PrivacyInfo.xcprivacy
+++ b/MacVitals/MacVitals/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/MacVitals/MacVitals/Services/SystemMonitor.swift
+++ b/MacVitals/MacVitals/Services/SystemMonitor.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+@MainActor
+class SystemMonitor: ObservableObject {
+    static let shared = SystemMonitor()
+
+    @Published var snapshot: SystemSnapshot?
+
+    private var timer: Timer?
+
+    private init() {}
+
+    func start() {
+        let interval = UserPreferences.shared.refreshRate.rawValue
+        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.collectSnapshot()
+            }
+        }
+        collectSnapshot()
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    func restart() {
+        stop()
+        start()
+    }
+
+    private func collectSnapshot() {
+        let uptime = ProcessInfo.processInfo.systemUptime
+
+        snapshot = SystemSnapshot(
+            timestamp: Date(),
+            cpu: .empty,
+            memory: .empty,
+            storage: .empty,
+            battery: nil,
+            thermal: .empty,
+            uptime: uptime
+        )
+    }
+}

--- a/MacVitals/MacVitals/Utilities/Constants.swift
+++ b/MacVitals/MacVitals/Utilities/Constants.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+enum Constants {
+    static let defaultRefreshInterval: TimeInterval = 2.0
+    static let popoverWidth: CGFloat = 420
+    static let popoverHeight: CGFloat = 550
+    static let appName = "MacVitals"
+    static let githubURL = "https://github.com/owieth/MacVitals"
+}

--- a/MacVitals/MacVitals/Utilities/Formatters.swift
+++ b/MacVitals/MacVitals/Utilities/Formatters.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+enum Formatters {
+    static func percentage(_ value: Double) -> String {
+        String(format: "%.0f%%", value)
+    }
+
+    static func bytes(_ value: UInt64) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .memory
+        return formatter.string(fromByteCount: Int64(value))
+    }
+
+    static func bytesDecimal(_ value: UInt64) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        return formatter.string(fromByteCount: Int64(value))
+    }
+
+    static func bytesPerSecond(_ value: UInt64) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .memory
+        formatter.includesUnit = true
+        return formatter.string(fromByteCount: Int64(value)) + "/s"
+    }
+
+    static func temperature(_ celsius: Double, unit: TemperatureUnit) -> String {
+        switch unit {
+        case .celsius:
+            return String(format: "%.0f°C", celsius)
+        case .fahrenheit:
+            let f = celsius * 9.0 / 5.0 + 32.0
+            return String(format: "%.0f°F", f)
+        }
+    }
+
+    static func uptime(_ interval: TimeInterval) -> String {
+        let totalSeconds = Int(interval)
+        let days = totalSeconds / 86400
+        let hours = (totalSeconds % 86400) / 3600
+        let minutes = (totalSeconds % 3600) / 60
+
+        if days > 0 {
+            return "\(days)d \(hours)h \(minutes)m"
+        } else if hours > 0 {
+            return "\(hours)h \(minutes)m"
+        } else {
+            return "\(minutes)m"
+        }
+    }
+
+    static func rpm(_ value: Int) -> String {
+        "\(value) RPM"
+    }
+}

--- a/MacVitals/MacVitals/Utilities/UserPreferences.swift
+++ b/MacVitals/MacVitals/Utilities/UserPreferences.swift
@@ -1,0 +1,129 @@
+import Foundation
+import ServiceManagement
+
+enum RefreshRate: Double, CaseIterable, Identifiable {
+    case oneSecond = 1.0
+    case twoSeconds = 2.0
+    case fiveSeconds = 5.0
+
+    var id: Double { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .oneSecond: return "1 second"
+        case .twoSeconds: return "2 seconds"
+        case .fiveSeconds: return "5 seconds"
+        }
+    }
+}
+
+enum TemperatureUnit: String, CaseIterable, Identifiable {
+    case celsius = "celsius"
+    case fahrenheit = "fahrenheit"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .celsius: return "°C"
+        case .fahrenheit: return "°F"
+        }
+    }
+}
+
+enum MenuBarDisplayMode: String, CaseIterable, Identifiable {
+    case iconOnly = "iconOnly"
+    case iconAndCPU = "iconAndCPU"
+    case iconAndTemp = "iconAndTemp"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .iconOnly: return "Icon only"
+        case .iconAndCPU: return "Icon + CPU %"
+        case .iconAndTemp: return "Icon + Temperature"
+        }
+    }
+}
+
+@MainActor
+class UserPreferences: ObservableObject {
+    static let shared = UserPreferences()
+
+    @Published var launchAtLogin: Bool {
+        didSet {
+            UserDefaults.standard.set(launchAtLogin, forKey: "launchAtLogin")
+            updateLaunchAtLogin()
+        }
+    }
+
+    @Published var refreshRate: RefreshRate {
+        didSet {
+            UserDefaults.standard.set(refreshRate.rawValue, forKey: "refreshRate")
+        }
+    }
+
+    @Published var menuBarDisplayMode: MenuBarDisplayMode {
+        didSet {
+            UserDefaults.standard.set(menuBarDisplayMode.rawValue, forKey: "menuBarDisplayMode")
+        }
+    }
+
+    @Published var temperatureUnit: TemperatureUnit {
+        didSet {
+            UserDefaults.standard.set(temperatureUnit.rawValue, forKey: "temperatureUnit")
+        }
+    }
+
+    @Published var showCPUSection: Bool {
+        didSet { UserDefaults.standard.set(showCPUSection, forKey: "showCPUSection") }
+    }
+
+    @Published var showMemorySection: Bool {
+        didSet { UserDefaults.standard.set(showMemorySection, forKey: "showMemorySection") }
+    }
+
+    @Published var showStorageSection: Bool {
+        didSet { UserDefaults.standard.set(showStorageSection, forKey: "showStorageSection") }
+    }
+
+    @Published var showBatterySection: Bool {
+        didSet { UserDefaults.standard.set(showBatterySection, forKey: "showBatterySection") }
+    }
+
+    @Published var showThermalSection: Bool {
+        didSet { UserDefaults.standard.set(showThermalSection, forKey: "showThermalSection") }
+    }
+
+    private init() {
+        self.launchAtLogin = UserDefaults.standard.bool(forKey: "launchAtLogin")
+
+        let savedRate = UserDefaults.standard.double(forKey: "refreshRate")
+        self.refreshRate = RefreshRate(rawValue: savedRate) ?? .twoSeconds
+
+        let savedMode = UserDefaults.standard.string(forKey: "menuBarDisplayMode") ?? MenuBarDisplayMode.iconOnly.rawValue
+        self.menuBarDisplayMode = MenuBarDisplayMode(rawValue: savedMode) ?? .iconOnly
+
+        let savedUnit = UserDefaults.standard.string(forKey: "temperatureUnit") ?? TemperatureUnit.celsius.rawValue
+        self.temperatureUnit = TemperatureUnit(rawValue: savedUnit) ?? .celsius
+
+        self.showCPUSection = UserDefaults.standard.object(forKey: "showCPUSection") as? Bool ?? true
+        self.showMemorySection = UserDefaults.standard.object(forKey: "showMemorySection") as? Bool ?? true
+        self.showStorageSection = UserDefaults.standard.object(forKey: "showStorageSection") as? Bool ?? true
+        self.showBatterySection = UserDefaults.standard.object(forKey: "showBatterySection") as? Bool ?? true
+        self.showThermalSection = UserDefaults.standard.object(forKey: "showThermalSection") as? Bool ?? true
+    }
+
+    private func updateLaunchAtLogin() {
+        do {
+            if launchAtLogin {
+                try SMAppService.mainApp.register()
+            } else {
+                try SMAppService.mainApp.unregister()
+            }
+        } catch {
+            print("Failed to update launch at login: \(error)")
+        }
+    }
+}

--- a/MacVitals/MacVitals/Utilities/WindowManager.swift
+++ b/MacVitals/MacVitals/Utilities/WindowManager.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+import AppKit
+
+@MainActor
+class WindowManager: ObservableObject {
+    static let shared = WindowManager()
+
+    private var settingsWindow: NSWindow?
+
+    private init() {}
+
+    func openSettingsWindow() {
+        if let window = settingsWindow, window.isVisible {
+            window.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        let settingsView = SettingsView()
+            .environmentObject(UserPreferences.shared)
+        let hostingController = NSHostingController(rootView: settingsView)
+
+        let window = NSWindow(contentViewController: hostingController)
+        window.title = "Settings"
+        window.styleMask = [.titled, .closable]
+        window.setContentSize(NSSize(width: 450, height: 350))
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+
+        settingsWindow = window
+        NSApp.activate(ignoringOtherApps: true)
+    }
+}

--- a/MacVitals/MacVitals/ViewModels/MenuBarViewModel.swift
+++ b/MacVitals/MacVitals/ViewModels/MenuBarViewModel.swift
@@ -1,0 +1,18 @@
+import Foundation
+import Combine
+
+@MainActor
+@Observable
+class MenuBarViewModel {
+    var snapshot: SystemSnapshot?
+
+    private var cancellable: AnyCancellable?
+
+    init() {
+        cancellable = SystemMonitor.shared.$snapshot
+            .receive(on: RunLoop.main)
+            .sink { [weak self] newSnapshot in
+                self?.snapshot = newSnapshot
+            }
+    }
+}

--- a/MacVitals/MacVitals/Views/BatterySectionView.swift
+++ b/MacVitals/MacVitals/Views/BatterySectionView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct BatterySectionView: View {
+    let battery: BatteryInfo
+
+    var body: some View {
+        DisclosureGroup("Battery") {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text(Formatters.percentage(battery.level))
+                        .font(.caption.monospacedDigit())
+                    if battery.isCharging {
+                        Image(systemName: "bolt.fill")
+                            .font(.caption)
+                            .foregroundStyle(.yellow)
+                        Text("Charging")
+                            .font(.caption)
+                    } else if battery.isPluggedIn {
+                        Text("Plugged In")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    Text("Health: \(Formatters.percentage(battery.health))")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                HStack(spacing: 16) {
+                    StatLabel(title: "Cycles", value: "\(battery.cycleCount)")
+                    if let remaining = battery.timeRemaining {
+                        StatLabel(title: "ETA", value: Formatters.uptime(remaining))
+                    }
+                }
+            }
+            .padding(.top, 4)
+        }
+    }
+}

--- a/MacVitals/MacVitals/Views/CPUSectionView.swift
+++ b/MacVitals/MacVitals/Views/CPUSectionView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct CPUSectionView: View {
+    let cpu: CPUInfo
+
+    var body: some View {
+        DisclosureGroup("CPU") {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 16) {
+                    StatLabel(title: "Total", value: Formatters.percentage(cpu.totalUsage))
+                    StatLabel(title: "User", value: Formatters.percentage(cpu.userUsage))
+                    StatLabel(title: "System", value: Formatters.percentage(cpu.systemUsage))
+                }
+
+                if !cpu.coreUsages.isEmpty {
+                    VStack(spacing: 2) {
+                        ForEach(Array(cpu.coreUsages.enumerated()), id: \.offset) { index, usage in
+                            HStack(spacing: 4) {
+                                Text("\(index)")
+                                    .font(.system(size: 9).monospacedDigit())
+                                    .foregroundStyle(.secondary)
+                                    .frame(width: 20, alignment: .trailing)
+                                ProgressView(value: min(max(usage / 100, 0), 1))
+                                    .tint(coreColor(usage))
+                                Text(Formatters.percentage(usage))
+                                    .font(.system(size: 9).monospacedDigit())
+                                    .foregroundStyle(.secondary)
+                                    .frame(width: 30, alignment: .trailing)
+                            }
+                        }
+                    }
+                }
+
+                if !cpu.topProcesses.isEmpty {
+                    Text("Top: " + cpu.topProcesses.map { "\($0.name) \(Formatters.percentage($0.cpuUsage))" }.joined(separator: " · "))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            .padding(.top, 4)
+        }
+    }
+
+    private func coreColor(_ usage: Double) -> Color {
+        if usage > 90 { return .red }
+        if usage > 70 { return .orange }
+        return .accentColor
+    }
+}
+
+struct StatLabel: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+            Text(value)
+                .font(.caption.monospacedDigit())
+        }
+    }
+}

--- a/MacVitals/MacVitals/Views/MemorySectionView.swift
+++ b/MacVitals/MacVitals/Views/MemorySectionView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct MemorySectionView: View {
+    let memory: MemoryInfo
+
+    var body: some View {
+        DisclosureGroup("Memory") {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("\(Formatters.bytes(memory.used)) / \(Formatters.bytes(memory.total))")
+                        .font(.caption.monospacedDigit())
+                    Spacer()
+                    PressureBadge(pressure: memory.pressure)
+                }
+
+                HStack(spacing: 16) {
+                    StatLabel(title: "Active", value: Formatters.bytes(memory.active))
+                    StatLabel(title: "Wired", value: Formatters.bytes(memory.wired))
+                    StatLabel(title: "Compressed", value: Formatters.bytes(memory.compressed))
+                }
+
+                if !memory.topProcesses.isEmpty {
+                    Text("Top: " + memory.topProcesses.map { "\($0.name) \(Formatters.bytes($0.memoryBytes))" }.joined(separator: " · "))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            .padding(.top, 4)
+        }
+    }
+}
+
+struct PressureBadge: View {
+    let pressure: MemoryPressure
+
+    var body: some View {
+        Text(pressure.rawValue)
+            .font(.caption2)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(backgroundColor.opacity(0.15))
+            .foregroundStyle(backgroundColor)
+            .clipShape(Capsule())
+    }
+
+    private var backgroundColor: Color {
+        switch pressure {
+        case .nominal: return .green
+        case .warning: return .orange
+        case .critical: return .red
+        }
+    }
+}

--- a/MacVitals/MacVitals/Views/MenuBarView.swift
+++ b/MacVitals/MacVitals/Views/MenuBarView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+struct MenuBarView: View {
+    @State private var viewModel = MenuBarViewModel()
+    @EnvironmentObject var preferences: UserPreferences
+
+    var body: some View {
+        VStack(spacing: 0) {
+            headerView
+            Divider()
+            ScrollView {
+                VStack(spacing: 12) {
+                    OverviewSection(snapshot: viewModel.snapshot)
+
+                    if preferences.showCPUSection {
+                        CPUSectionView(cpu: viewModel.snapshot?.cpu ?? .empty)
+                    }
+
+                    if preferences.showMemorySection {
+                        MemorySectionView(memory: viewModel.snapshot?.memory ?? .empty)
+                    }
+
+                    if preferences.showStorageSection {
+                        StorageSectionView(storage: viewModel.snapshot?.storage ?? .empty)
+                    }
+
+                    if preferences.showBatterySection, let battery = viewModel.snapshot?.battery {
+                        BatterySectionView(battery: battery)
+                    }
+
+                    if preferences.showThermalSection {
+                        ThermalSectionView(thermal: viewModel.snapshot?.thermal ?? .empty)
+                    }
+                }
+                .padding(16)
+            }
+        }
+        .frame(
+            width: Constants.popoverWidth,
+            height: Constants.popoverHeight
+        )
+    }
+
+    private var headerView: some View {
+        HStack {
+            Button(action: { WindowManager.shared.openSettingsWindow() }) {
+                Image(systemName: "gear")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+
+            Spacer()
+
+            Text(Constants.appName)
+                .font(.headline)
+
+            Spacer()
+
+            Button(action: { openGitHub() }) {
+                Image(systemName: "arrow.up.right.square")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private func openGitHub() {
+        if let url = URL(string: Constants.githubURL) {
+            NSWorkspace.shared.open(url)
+        }
+    }
+}

--- a/MacVitals/MacVitals/Views/OverviewSection.swift
+++ b/MacVitals/MacVitals/Views/OverviewSection.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct OverviewSection: View {
+    let snapshot: SystemSnapshot?
+
+    var body: some View {
+        VStack(spacing: 8) {
+            if let snapshot {
+                Text("Uptime: \(Formatters.uptime(snapshot.uptime))")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                HStack(spacing: 16) {
+                    MetricBar(
+                        label: "CPU",
+                        value: snapshot.cpu.totalUsage / 100,
+                        displayValue: Formatters.percentage(snapshot.cpu.totalUsage)
+                    )
+                    MetricBar(
+                        label: "Memory",
+                        value: snapshot.memory.usagePercentage / 100,
+                        displayValue: Formatters.percentage(snapshot.memory.usagePercentage)
+                    )
+                }
+            } else {
+                Text("Loading...")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+struct MetricBar: View {
+    let label: String
+    let value: Double
+    let displayValue: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(label)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text(displayValue)
+                    .font(.caption.monospacedDigit())
+            }
+            ProgressView(value: min(max(value, 0), 1))
+                .tint(colorForValue(value))
+        }
+    }
+
+    private func colorForValue(_ value: Double) -> Color {
+        if value > 0.9 { return .red }
+        if value > 0.7 { return .orange }
+        return .accentColor
+    }
+}

--- a/MacVitals/MacVitals/Views/SettingsView.swift
+++ b/MacVitals/MacVitals/Views/SettingsView.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @EnvironmentObject var preferences: UserPreferences
+
+    var body: some View {
+        TabView {
+            GeneralSettingsView()
+                .tabItem { Label("General", systemImage: "gear") }
+                .environmentObject(preferences)
+
+            DisplaySettingsView()
+                .tabItem { Label("Display", systemImage: "eye") }
+                .environmentObject(preferences)
+
+            AboutSettingsView()
+                .tabItem { Label("About", systemImage: "info.circle") }
+        }
+        .frame(width: 420, height: 320)
+    }
+}
+
+struct GeneralSettingsView: View {
+    @EnvironmentObject var preferences: UserPreferences
+
+    var body: some View {
+        Form {
+            Toggle("Launch at login", isOn: $preferences.launchAtLogin)
+
+            Picker("Refresh rate", selection: $preferences.refreshRate) {
+                ForEach(RefreshRate.allCases) { rate in
+                    Text(rate.displayName).tag(rate)
+                }
+            }
+            .onChange(of: preferences.refreshRate) {
+                SystemMonitor.shared.restart()
+            }
+
+            Picker("Menu bar display", selection: $preferences.menuBarDisplayMode) {
+                ForEach(MenuBarDisplayMode.allCases) { mode in
+                    Text(mode.displayName).tag(mode)
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+}
+
+struct DisplaySettingsView: View {
+    @EnvironmentObject var preferences: UserPreferences
+
+    var body: some View {
+        Form {
+            Picker("Temperature unit", selection: $preferences.temperatureUnit) {
+                ForEach(TemperatureUnit.allCases) { unit in
+                    Text(unit.displayName).tag(unit)
+                }
+            }
+
+            Section("Visible Sections") {
+                Toggle("CPU", isOn: $preferences.showCPUSection)
+                Toggle("Memory", isOn: $preferences.showMemorySection)
+                Toggle("Storage", isOn: $preferences.showStorageSection)
+                Toggle("Battery", isOn: $preferences.showBatterySection)
+                Toggle("Thermals", isOn: $preferences.showThermalSection)
+            }
+        }
+        .formStyle(.grouped)
+    }
+}
+
+struct AboutSettingsView: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            Spacer()
+
+            Image(systemName: "gauge.with.dots.needle.bottom.50percent")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+
+            Text(Constants.appName)
+                .font(.title2.bold())
+
+            if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+                Text("Version \(version)")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            Button("View on GitHub") {
+                if let url = URL(string: Constants.githubURL) {
+                    NSWorkspace.shared.open(url)
+                }
+            }
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+}

--- a/MacVitals/MacVitals/Views/StorageSectionView.swift
+++ b/MacVitals/MacVitals/Views/StorageSectionView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct StorageSectionView: View {
+    let storage: StorageInfo
+
+    var body: some View {
+        DisclosureGroup("Storage") {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("\(Formatters.bytesDecimal(storage.used)) / \(Formatters.bytesDecimal(storage.total))")
+                        .font(.caption.monospacedDigit())
+                    Spacer()
+                    Text(Formatters.percentage(storage.usagePercentage))
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+
+                ProgressView(value: min(max(storage.usagePercentage / 100, 0), 1))
+                    .tint(storage.usagePercentage > 90 ? .red : .accentColor)
+
+                HStack(spacing: 16) {
+                    StatLabel(title: "Read", value: Formatters.bytesPerSecond(storage.readBytesPerSec))
+                    StatLabel(title: "Write", value: Formatters.bytesPerSecond(storage.writeBytesPerSec))
+                }
+            }
+            .padding(.top, 4)
+        }
+    }
+}

--- a/MacVitals/MacVitals/Views/ThermalSectionView.swift
+++ b/MacVitals/MacVitals/Views/ThermalSectionView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct ThermalSectionView: View {
+    let thermal: ThermalInfo
+    @EnvironmentObject var preferences: UserPreferences
+
+    var body: some View {
+        DisclosureGroup("Thermals") {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 16) {
+                    if let cpuTemp = thermal.cpuTemperature {
+                        StatLabel(
+                            title: "CPU",
+                            value: Formatters.temperature(cpuTemp, unit: preferences.temperatureUnit)
+                        )
+                    }
+                    if let gpuTemp = thermal.gpuTemperature {
+                        StatLabel(
+                            title: "GPU",
+                            value: Formatters.temperature(gpuTemp, unit: preferences.temperatureUnit)
+                        )
+                    }
+                }
+
+                ForEach(thermal.fans) { fan in
+                    HStack {
+                        Text("Fan \(fan.id + 1)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text(Formatters.rpm(fan.currentRPM))
+                            .font(.caption.monospacedDigit())
+                    }
+                }
+
+                if thermal.cpuTemperature == nil && thermal.gpuTemperature == nil && thermal.fans.isEmpty {
+                    Text("No thermal data available")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.top, 4)
+        }
+    }
+}

--- a/MacVitals/MacVitalsTests/MacVitalsTests.swift
+++ b/MacVitals/MacVitalsTests/MacVitalsTests.swift
@@ -1,0 +1,50 @@
+import Testing
+@testable import MacVitals
+
+struct MacVitalsTests {
+    @Test func formatPercentage() async throws {
+        #expect(Formatters.percentage(62.4) == "62%")
+        #expect(Formatters.percentage(0) == "0%")
+        #expect(Formatters.percentage(100) == "100%")
+    }
+
+    @Test func formatUptime() async throws {
+        #expect(Formatters.uptime(3600) == "1h 0m")
+        #expect(Formatters.uptime(90000) == "1d 1h 0m")
+        #expect(Formatters.uptime(300) == "5m")
+    }
+
+    @Test func formatTemperatureCelsius() async throws {
+        #expect(Formatters.temperature(62.0, unit: .celsius) == "62°C")
+    }
+
+    @Test func formatTemperatureFahrenheit() async throws {
+        #expect(Formatters.temperature(0.0, unit: .fahrenheit) == "32°F")
+        #expect(Formatters.temperature(100.0, unit: .fahrenheit) == "212°F")
+    }
+
+    @Test func memoryUsagePercentage() async throws {
+        let info = MemoryInfo(
+            total: 16_000_000_000,
+            used: 8_000_000_000,
+            active: 4_000_000_000,
+            wired: 2_000_000_000,
+            compressed: 1_000_000_000,
+            available: 8_000_000_000,
+            pressure: .nominal,
+            topProcesses: []
+        )
+        #expect(info.usagePercentage == 50.0)
+    }
+
+    @Test func storageUsagePercentage() async throws {
+        let info = StorageInfo(
+            total: 500_000_000_000,
+            used: 250_000_000_000,
+            free: 250_000_000_000,
+            readBytesPerSec: 0,
+            writeBytesPerSec: 0
+        )
+        #expect(info.usagePercentage == 50.0)
+    }
+}


### PR DESCRIPTION
## Summary

- Xcode project (Swift 6, macOS 15+, non-sandboxed, no SPM deps) with app + test targets
- AppDelegate with NSStatusItem, NSPopover (420×550), right-click context menu
- All data models: SystemSnapshot, CPUInfo, MemoryInfo, StorageInfo, BatteryInfo, ThermalInfo, ProcessSnapshot
- SystemMonitor stub (timer-based orchestrator), MenuBarViewModel (@Observable)
- Full popover UI with DisclosureGroup sections for CPU, Memory, Storage, Battery, Thermals
- Settings window with General/Display/About tabs, launch at login via SMAppService
- UserPreferences, Formatters, Constants, WindowManager utilities
- 6 unit tests for formatters and model calculations

## Test plan

- [x] `xcodebuild build` succeeds
- [x] `xcodebuild test` passes (6/6)
- [ ] Run app → menu bar icon appears, no dock icon
- [ ] Click icon → popover toggles
- [ ] Right-click → context menu with Settings/Quit
- [ ] Settings window opens from gear icon and context menu

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)