### PR TITLE
chore: remove dead code (defaultRefreshInterval, batteryIOMainPort)

### DIFF
--- a/MacVitals/MacVitals/Services/BatteryCollector.swift
+++ b/MacVitals/MacVitals/Services/BatteryCollector.swift
@@ -1,8 +1,6 @@
 import Foundation
 import IOKit.ps
 
-private let batteryIOMainPort = kIOMainPortDefault
-
 struct BatteryCollector {
     func collect() -> BatteryInfo? {
         guard let snapshot = IOPSCopyPowerSourcesInfo()?.takeRetainedValue(),
@@ -30,7 +28,7 @@ struct BatteryCollector {
         var temperature: Double?
 
         let matchingDict = IOServiceMatching("AppleSmartBattery")
-        let service = IOServiceGetMatchingService(batteryIOMainPort, matchingDict)
+        let service = IOServiceGetMatchingService(kIOMainPortDefault, matchingDict)
         if service != 0 {
             var props: Unmanaged<CFMutableDictionary>?
             if IORegistryEntryCreateCFProperties(

--- a/MacVitals/MacVitals/Utilities/Constants.swift
+++ b/MacVitals/MacVitals/Utilities/Constants.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 enum Constants {
-    static let defaultRefreshInterval: TimeInterval = 2.0
     static let popoverWidth: CGFloat = 420
     static let popoverHeight: CGFloat = 550
     static let appName = "MacVitals"


### PR DESCRIPTION
## Summary
- Remove `Constants.defaultRefreshInterval` (never referenced; actual default is `RefreshRate.twoSeconds`)
- Remove unused `batteryIOMainPort` alias in `BatteryCollector`

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)