### PR TITLE
refactor(settings): remove redundant .environmentObject() on tab children

### DIFF
--- a/MacVitals/MacVitals/Views/SettingsView.swift
+++ b/MacVitals/MacVitals/Views/SettingsView.swift
@@ -7,11 +7,9 @@ struct SettingsView: View {
         TabView {
             GeneralSettingsView()
                 .tabItem { Label("General", systemImage: "gear") }
-                .environmentObject(preferences)
 
             DisplaySettingsView()
                 .tabItem { Label("Display", systemImage: "eye") }
-                .environmentObject(preferences)
 
             AboutSettingsView()
                 .tabItem { Label("About", systemImage: "info.circle") }


### PR DESCRIPTION
## Summary
- Remove redundant `.environmentObject(preferences)` calls on TabView children — SwiftUI inherits environment automatically

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)