### PR TITLE
fix(smc): close existing connection before reopening

### DIFF
--- a/MacVitals/MacVitals/Services/SMCClient.swift
+++ b/MacVitals/MacVitals/Services/SMCClient.swift
@@ -47,6 +47,7 @@ class SMCClient {
     private var isOpen = false
 
     func open() -> Bool {
+        if isOpen { close() }
         let service = IOServiceGetMatchingService(
             ioMainPort, IOServiceMatching("AppleSMC")
         )


### PR DESCRIPTION
## Summary
- Add `if isOpen { close() }` guard at the top of `open()` to prevent connection handle leaks

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)