### PR TITLE
fix(monitor): prevent timer stacking on repeated start()

### DIFF
--- a/MacVitals/MacVitals/Services/SystemMonitor.swift
+++ b/MacVitals/MacVitals/Services/SystemMonitor.swift
@@ -18,6 +18,7 @@ class SystemMonitor: ObservableObject {
     private init() {}
 
     func start() {
+        stop()
         _ = smcClient.open()
 
         let interval = UserPreferences.shared.refreshRate.rawValue


### PR DESCRIPTION
## Summary
- Call `stop()` at the beginning of `start()` to invalidate any existing timer before creating a new one

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)