### PR TITLE
chore: remove identical kIOMainPortDefault aliases

### DIFF
--- a/MacVitals/MacVitals/Services/BatteryCollector.swift
+++ b/MacVitals/MacVitals/Services/BatteryCollector.swift
@@ -1,8 +1,6 @@
 import Foundation
 import IOKit.ps
 
-private let batteryIOMainPort = kIOMainPortDefault
-
 struct BatteryCollector {
     func collect() -> BatteryInfo? {
         guard let snapshot = IOPSCopyPowerSourcesInfo()?.takeRetainedValue(),
@@ -30,7 +28,7 @@ struct BatteryCollector {
         var temperature: Double?
 
         let matchingDict = IOServiceMatching("AppleSmartBattery")
-        let service = IOServiceGetMatchingService(batteryIOMainPort, matchingDict)
+        let service = IOServiceGetMatchingService(kIOMainPortDefault, matchingDict)
         if service != 0 {
             var props: Unmanaged<CFMutableDictionary>?
             if IORegistryEntryCreateCFProperties(

--- a/MacVitals/MacVitals/Services/SMCClient.swift
+++ b/MacVitals/MacVitals/Services/SMCClient.swift
@@ -1,8 +1,6 @@
 import Foundation
 import IOKit
 
-private let ioMainPort = kIOMainPortDefault
-
 struct SMCKeyData {
     struct Version {
         var major: UInt8 = 0
@@ -48,7 +46,7 @@ class SMCClient {
 
     func open() -> Bool {
         let service = IOServiceGetMatchingService(
-            ioMainPort, IOServiceMatching("AppleSMC")
+            kIOMainPortDefault, IOServiceMatching("AppleSMC")
         )
         guard service != 0 else { return false }
         let result = IOServiceOpen(service, mv_mach_task_self(), 0, &connection)

--- a/MacVitals/MacVitals/Services/StorageCollector.swift
+++ b/MacVitals/MacVitals/Services/StorageCollector.swift
@@ -1,8 +1,6 @@
 import Foundation
 import IOKit
 
-private let storageIOMainPort = kIOMainPortDefault
-
 struct StorageCollector {
     private var previousReadBytes: UInt64 = 0
     private var previousWriteBytes: UInt64 = 0
@@ -21,7 +19,7 @@ struct StorageCollector {
 
         let matching = IOServiceMatching("IOBlockStorageDriver")
         var iterator: io_iterator_t = 0
-        if IOServiceGetMatchingServices(storageIOMainPort, matching, &iterator) == KERN_SUCCESS {
+        if IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iterator) == KERN_SUCCESS {
             var service = IOIteratorNext(iterator)
             while service != 0 {
                 if let props = serviceProperties(service) {


### PR DESCRIPTION
## Summary
- Remove 3 per-file private aliases for `kIOMainPortDefault` and use the constant directly

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)