### PR TITLE
refactor: deduplicate openGitHub into Constants helper

### DIFF
--- a/MacVitals/MacVitals/Utilities/Constants.swift
+++ b/MacVitals/MacVitals/Utilities/Constants.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AppKit
 
 enum Constants {
     static let defaultRefreshInterval: TimeInterval = 2.0
@@ -6,4 +7,10 @@ enum Constants {
     static let popoverHeight: CGFloat = 550
     static let appName = "MacVitals"
     static let githubURL = "https://github.com/owieth/MacVitals"
+
+    static func openGitHub() {
+        if let url = URL(string: githubURL) {
+            NSWorkspace.shared.open(url)
+        }
+    }
 }

--- a/MacVitals/MacVitals/Views/MenuBarView.swift
+++ b/MacVitals/MacVitals/Views/MenuBarView.swift
@@ -57,7 +57,7 @@ struct MenuBarView: View {
 
             Spacer()
 
-            Button(action: { openGitHub() }) {
+            Button(action: { Constants.openGitHub() }) {
                 Image(systemName: "arrow.up.right.square")
                     .font(.system(size: 14))
                     .foregroundStyle(.secondary)
@@ -68,9 +68,4 @@ struct MenuBarView: View {
         .padding(.vertical, 12)
     }
 
-    private func openGitHub() {
-        if let url = URL(string: Constants.githubURL) {
-            NSWorkspace.shared.open(url)
-        }
-    }
 }

--- a/MacVitals/MacVitals/Views/SettingsView.swift
+++ b/MacVitals/MacVitals/Views/SettingsView.swift
@@ -89,9 +89,7 @@ struct AboutSettingsView: View {
             }
 
             Button("View on GitHub") {
-                if let url = URL(string: Constants.githubURL) {
-                    NSWorkspace.shared.open(url)
-                }
+                Constants.openGitHub()
             }
 
             Spacer()


### PR DESCRIPTION
## Summary
- Extract `Constants.openGitHub()` shared helper
- Replace duplicate URL-opening logic in MenuBarView and SettingsView

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)