### PR TITLE
refactor(thermal): simplify temperature search with lazy compactMap

### DIFF
--- a/MacVitals/MacVitals/Models/ThermalInfo.swift
+++ b/MacVitals/MacVitals/Models/ThermalInfo.swift
@@ -12,6 +12,10 @@ struct ThermalInfo {
     let gpuTemperature: Double?
     let fans: [FanInfo]
 
+    var isEmpty: Bool {
+        cpuTemperature == nil && gpuTemperature == nil && fans.isEmpty
+    }
+
     static let empty = ThermalInfo(
         cpuTemperature: nil,
         gpuTemperature: nil,

--- a/MacVitals/MacVitals/Services/ThermalCollector.swift
+++ b/MacVitals/MacVitals/Services/ThermalCollector.swift
@@ -5,21 +5,13 @@ struct ThermalCollector {
     private let gpuTempKeys = ["TG0P", "Tg05", "Tg0P"]
 
     func collect(using smc: SMCClient) -> ThermalInfo {
-        var cpuTemp: Double?
-        for key in cpuTempKeys {
-            if let temp = smc.readTemperature(key: key), temp > 0, temp < 150 {
-                cpuTemp = temp
-                break
-            }
-        }
+        let cpuTemp = cpuTempKeys.lazy
+            .compactMap { smc.readTemperature(key: $0) }
+            .first { $0 > 0 && $0 < 150 }
 
-        var gpuTemp: Double?
-        for key in gpuTempKeys {
-            if let temp = smc.readTemperature(key: key), temp > 0, temp < 150 {
-                gpuTemp = temp
-                break
-            }
-        }
+        let gpuTemp = gpuTempKeys.lazy
+            .compactMap { smc.readTemperature(key: $0) }
+            .first { $0 > 0 && $0 < 150 }
 
         let fanCount = smc.readFanCount()
         var fans: [FanInfo] = []

--- a/MacVitals/MacVitals/Views/ThermalSectionView.swift
+++ b/MacVitals/MacVitals/Views/ThermalSectionView.swift
@@ -33,7 +33,7 @@ struct ThermalSectionView: View {
                     }
                 }
 
-                if thermal.cpuTemperature == nil && thermal.gpuTemperature == nil && thermal.fans.isEmpty {
+                if thermal.isEmpty {
                     Text("No thermal data available")
                         .font(.caption)
                         .foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary
- Replace for-break loops with `lazy.compactMap.first` for CPU/GPU temp lookup
- Add `isEmpty` computed property to `ThermalInfo`
- Use `thermal.isEmpty` in `ThermalSectionView`

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)