### PR TITLE
refactor(views): extract shared Color.forUsage threshold function

### DIFF
--- a/MacVitals/MacVitals/Views/CPUSectionView.swift
+++ b/MacVitals/MacVitals/Views/CPUSectionView.swift
@@ -43,9 +43,7 @@ struct CPUSectionView: View {
     }
 
     private func coreColor(_ usage: Double) -> Color {
-        if usage > 90 { return .red }
-        if usage > 70 { return .orange }
-        return .accentColor
+        .forUsage(usage)
     }
 }
 

--- a/MacVitals/MacVitals/Views/OverviewSection.swift
+++ b/MacVitals/MacVitals/Views/OverviewSection.swift
@@ -53,8 +53,14 @@ struct MetricBar: View {
     }
 
     private func colorForValue(_ value: Double) -> Color {
-        if value > 0.9 { return .red }
-        if value > 0.7 { return .orange }
+        .forUsage(value * 100)
+    }
+}
+
+extension Color {
+    static func forUsage(_ percentage: Double) -> Color {
+        if percentage > 90 { return .red }
+        if percentage > 70 { return .orange }
         return .accentColor
     }
 }

--- a/MacVitals/MacVitals/Views/StorageSectionView.swift
+++ b/MacVitals/MacVitals/Views/StorageSectionView.swift
@@ -16,7 +16,7 @@ struct StorageSectionView: View {
                 }
 
                 ProgressView(value: min(max(storage.usagePercentage / 100, 0), 1))
-                    .tint(storage.usagePercentage > 90 ? .red : .accentColor)
+                    .tint(.forUsage(storage.usagePercentage))
 
                 HStack(spacing: 16) {
                     StatLabel(title: "Read", value: Formatters.bytesPerSecond(storage.readBytesPerSec))


### PR DESCRIPTION
## Summary
- Add `Color.forUsage(_:)` extension for green/orange/red at 70%/90%
- Replace duplicated threshold logic in OverviewSection, CPUSectionView, and StorageSectionView

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)