### PR TITLE
refactor(smc): extract shared readFPE2 helper for fan methods

### DIFF
--- a/MacVitals/MacVitals/Services/SMCClient.swift
+++ b/MacVitals/MacVitals/Services/SMCClient.swift
@@ -71,22 +71,19 @@ class SMCClient {
     }
 
     func readFanSpeed(index: Int) -> Int? {
-        let key = "F\(index)Ac"
-        guard let bytes = readKey(key: key, dataSize: 2) else { return nil }
-        let value = (UInt(bytes[0]) << 8) | UInt(bytes[1])
-        return Int(value >> 2)
+        readFPE2(index: index, suffix: "Ac")
     }
 
     func readFanMin(index: Int) -> Int? {
-        let key = "F\(index)Mn"
-        guard let bytes = readKey(key: key, dataSize: 2) else { return nil }
-        let value = (UInt(bytes[0]) << 8) | UInt(bytes[1])
-        return Int(value >> 2)
+        readFPE2(index: index, suffix: "Mn")
     }
 
     func readFanMax(index: Int) -> Int? {
-        let key = "F\(index)Mx"
-        guard let bytes = readKey(key: key, dataSize: 2) else { return nil }
+        readFPE2(index: index, suffix: "Mx")
+    }
+
+    private func readFPE2(index: Int, suffix: String) -> Int? {
+        guard let bytes = readKey(key: "F\(index)\(suffix)", dataSize: 2) else { return nil }
         let value = (UInt(bytes[0]) << 8) | UInt(bytes[1])
         return Int(value >> 2)
     }
@@ -103,7 +100,8 @@ class SMCClient {
         var outputStruct = SMCKeyData()
 
         inputStruct.key = stringToUInt32(key)
-        inputStruct.data8 = 5 // kSMCReadKey
+        let kSMCReadKey: UInt8 = 5
+        inputStruct.data8 = kSMCReadKey
         inputStruct.keyInfo.dataSize = dataSize
 
         let inputSize = MemoryLayout<SMCKeyData>.size
@@ -112,6 +110,7 @@ class SMCClient {
         let result = IOConnectCallStructMethod(
             connection,
             2, // kSMCHandleYPCEvent
+            // selector for SMC read/write operations
             &inputStruct,
             inputSize,
             &outputStruct,


### PR DESCRIPTION
## Summary
- Extract shared `readFPE2(index:suffix:)` method
- Replace 3 copy-pasted readFanSpeed/Min/Max bodies with one-line delegations

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)