### PR TITLE
refactor(models): add with(topProcesses:) to CPUInfo and MemoryInfo

### DIFF
--- a/MacVitals/MacVitals/Models/CPUInfo.swift
+++ b/MacVitals/MacVitals/Models/CPUInfo.swift
@@ -15,3 +15,15 @@ struct CPUInfo {
         topProcesses: []
     )
 }
+
+extension CPUInfo {
+    func with(topProcesses: [ProcessSnapshot]) -> CPUInfo {
+        CPUInfo(
+            totalUsage: totalUsage,
+            userUsage: userUsage,
+            systemUsage: systemUsage,
+            coreUsages: coreUsages,
+            topProcesses: topProcesses
+        )
+    }
+}

--- a/MacVitals/MacVitals/Models/MemoryInfo.swift
+++ b/MacVitals/MacVitals/Models/MemoryInfo.swift
@@ -32,3 +32,18 @@ struct MemoryInfo {
         topProcesses: []
     )
 }
+
+extension MemoryInfo {
+    func with(topProcesses: [ProcessSnapshot]) -> MemoryInfo {
+        MemoryInfo(
+            total: total,
+            used: used,
+            active: active,
+            wired: wired,
+            compressed: compressed,
+            available: available,
+            pressure: pressure,
+            topProcesses: topProcesses
+        )
+    }
+}

--- a/MacVitals/MacVitals/Services/SystemMonitor.swift
+++ b/MacVitals/MacVitals/Services/SystemMonitor.swift
@@ -51,29 +51,10 @@ class SystemMonitor: ObservableObject {
         let topByCPU = processCollector.collectTopByCPU()
         let topByMemory = processCollector.collectTopByMemory()
 
-        let cpuWithProcesses = CPUInfo(
-            totalUsage: cpu.totalUsage,
-            userUsage: cpu.userUsage,
-            systemUsage: cpu.systemUsage,
-            coreUsages: cpu.coreUsages,
-            topProcesses: topByCPU
-        )
-
-        let memoryWithProcesses = MemoryInfo(
-            total: memory.total,
-            used: memory.used,
-            active: memory.active,
-            wired: memory.wired,
-            compressed: memory.compressed,
-            available: memory.available,
-            pressure: memory.pressure,
-            topProcesses: topByMemory
-        )
-
         snapshot = SystemSnapshot(
             timestamp: Date(),
-            cpu: cpuWithProcesses,
-            memory: memoryWithProcesses,
+            cpu: cpu.with(topProcesses: topByCPU),
+            memory: memory.with(topProcesses: topByMemory),
             storage: storage,
             battery: battery,
             thermal: thermal,


### PR DESCRIPTION
## Summary
- Add `with(topProcesses:)` helper to CPUInfo and MemoryInfo
- Replace 15+ lines of field-by-field struct reconstruction in SystemMonitor

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)