### PR TITLE
refactor(viewmodel): remove redundant Combine bridge in MenuBarViewModel

### DIFF
--- a/MacVitals/MacVitals/ViewModels/MenuBarViewModel.swift
+++ b/MacVitals/MacVitals/ViewModels/MenuBarViewModel.swift
@@ -1,18 +1,9 @@
 import Foundation
-import Combine
 
 @MainActor
 @Observable
 class MenuBarViewModel {
-    var snapshot: SystemSnapshot?
-
-    private var cancellable: AnyCancellable?
-
-    init() {
-        cancellable = SystemMonitor.shared.$snapshot
-            .receive(on: RunLoop.main)
-            .sink { [weak self] newSnapshot in
-                self?.snapshot = newSnapshot
-            }
+    var snapshot: SystemSnapshot? {
+        SystemMonitor.shared.snapshot
     }
 }


### PR DESCRIPTION
## Summary
- Replace Combine sink with computed property that reads `SystemMonitor.shared.snapshot` directly
- Both are `@MainActor`, so the Combine bridge + `receive(on: RunLoop.main)` was unnecessary

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)