### PR TITLE
perf(process): enumerate PIDs once per tick instead of twice

### DIFF
--- a/MacVitals/MacVitals/Services/ProcessCollector.swift
+++ b/MacVitals/MacVitals/Services/ProcessCollector.swift
@@ -4,14 +4,11 @@ import Darwin
 struct ProcessCollector {
     private var previousSamples: [Int32: (totalTime: UInt64, timestamp: TimeInterval)] = [:]
 
-    mutating func collectTopByCPU(limit: Int = 5) -> [ProcessSnapshot] {
+    mutating func collectTop(cpuLimit: Int = 5, memoryLimit: Int = 5) -> (cpu: [ProcessSnapshot], memory: [ProcessSnapshot]) {
         let processes = gatherProcesses()
-        return Array(processes.sorted { $0.cpuUsage > $1.cpuUsage }.prefix(limit))
-    }
-
-    mutating func collectTopByMemory(limit: Int = 5) -> [ProcessSnapshot] {
-        let processes = gatherProcesses()
-        return Array(processes.sorted { $0.memoryBytes > $1.memoryBytes }.prefix(limit))
+        let topCPU = Array(processes.sorted { $0.cpuUsage > $1.cpuUsage }.prefix(cpuLimit))
+        let topMemory = Array(processes.sorted { $0.memoryBytes > $1.memoryBytes }.prefix(memoryLimit))
+        return (topCPU, topMemory)
     }
 
     private mutating func gatherProcesses() -> [ProcessSnapshot] {

--- a/MacVitals/MacVitals/Services/SystemMonitor.swift
+++ b/MacVitals/MacVitals/Services/SystemMonitor.swift
@@ -56,8 +56,9 @@ class SystemMonitor: ObservableObject {
         let topByCPU: [ProcessSnapshot]
         let topByMemory: [ProcessSnapshot]
         if shouldCollectProcesses {
-            topByCPU = processCollector.collectTopByCPU()
-            topByMemory = processCollector.collectTopByMemory()
+            let topProcesses = processCollector.collectTop()
+            topByCPU = topProcesses.cpu
+            topByMemory = topProcesses.memory
         } else {
             topByCPU = snapshot?.cpu.topProcesses ?? []
             topByMemory = snapshot?.memory.topProcesses ?? []


### PR DESCRIPTION
## Summary
- Add `collectTop()` that returns both CPU and memory sorted lists from a single process enumeration
- Eliminates redundant `gatherProcesses()` → `allPids()` → N × `proc_pidinfo()` calls

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)