### PR TITLE
fix(thermal): split empty state for temps vs fans

### DIFF
--- a/MacVitals/MacVitals/Views/ThermalSectionView.swift
+++ b/MacVitals/MacVitals/Views/ThermalSectionView.swift
@@ -7,30 +7,38 @@ struct ThermalSectionView: View {
     var body: some View {
         DisclosureGroup("Thermals") {
             VStack(alignment: .leading, spacing: 8) {
-                HStack(spacing: 16) {
-                    if let cpuTemp = thermal.cpuTemperature {
-                        StatLabel(
-                            title: "CPU",
-                            value: Formatters.temperature(cpuTemp, unit: preferences.temperatureUnit)
-                        )
-                    }
-                    if let gpuTemp = thermal.gpuTemperature {
-                        StatLabel(
-                            title: "GPU",
-                            value: Formatters.temperature(gpuTemp, unit: preferences.temperatureUnit)
-                        )
+                if thermal.cpuTemperature != nil || thermal.gpuTemperature != nil {
+                    HStack(spacing: 16) {
+                        if let cpuTemp = thermal.cpuTemperature {
+                            StatLabel(
+                                title: "CPU",
+                                value: Formatters.temperature(cpuTemp, unit: preferences.temperatureUnit)
+                            )
+                        }
+                        if let gpuTemp = thermal.gpuTemperature {
+                            StatLabel(
+                                title: "GPU",
+                                value: Formatters.temperature(gpuTemp, unit: preferences.temperatureUnit)
+                            )
+                        }
                     }
                 }
 
-                ForEach(thermal.fans) { fan in
-                    HStack {
-                        Text("Fan \(fan.id + 1)")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        Spacer()
-                        Text(Formatters.rpm(fan.currentRPM))
-                            .font(.caption.monospacedDigit())
+                if !thermal.fans.isEmpty {
+                    ForEach(thermal.fans) { fan in
+                        HStack {
+                            Text("Fan \(fan.id + 1)")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                            Text(Formatters.rpm(fan.currentRPM))
+                                .font(.caption.monospacedDigit())
+                        }
                     }
+                } else if thermal.cpuTemperature != nil || thermal.gpuTemperature != nil {
+                    Text("No fans detected")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
 
                 if thermal.cpuTemperature == nil && thermal.gpuTemperature == nil && thermal.fans.isEmpty {


### PR DESCRIPTION
## Summary
- Show temperature readings independently from fan data
- Display "No fans detected" when fans are empty but temperatures exist (e.g., MacBook Air)
- Keep "No thermal data available" only when everything is truly empty

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)