### PR TITLE
fix(memory): document ratio-based memory pressure heuristic

### DIFF
--- a/MacVitals/MacVitals/Services/MemoryCollector.swift
+++ b/MacVitals/MacVitals/Services/MemoryCollector.swift
@@ -26,6 +26,10 @@ struct MemoryCollector {
         let used = active + wired + compressed
         let available = free + inactive
 
+        // Heuristic based on used/total ratio. macOS DISPATCH_SOURCE_TYPE_MEMORYPRESSURE
+        // provides real OS-level pressure events but requires a long-lived dispatch source,
+        // which doesn't fit the polling collector model. This ratio approximation is
+        // sufficient for UI indication purposes.
         let usageRatio = Double(used) / Double(total)
         let pressure: MemoryPressure
         if usageRatio > 0.9 { pressure = .critical }


### PR DESCRIPTION
## Summary
- Add documentation comment explaining why `DISPATCH_SOURCE_TYPE_MEMORYPRESSURE` is not used
- Clarify that the ratio-based pressure heuristic is intentional for the polling collector model

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)