### PR TITLE
perf: cache formatters and throttle process collection

### DIFF
--- a/MacVitals/MacVitals/AppDelegate.swift
+++ b/MacVitals/MacVitals/AppDelegate.swift
@@ -90,9 +90,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         guard let popover = popover, let button = statusItem?.button else { return }
         if popover.isShown {
             popover.performClose(nil)
+            SystemMonitor.shared.isPopoverVisible = false
         } else {
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
             NSApp.activate(ignoringOtherApps: true)
+            SystemMonitor.shared.isPopoverVisible = true
         }
     }
 

--- a/MacVitals/MacVitals/Services/SystemMonitor.swift
+++ b/MacVitals/MacVitals/Services/SystemMonitor.swift
@@ -5,8 +5,10 @@ class SystemMonitor: ObservableObject {
     static let shared = SystemMonitor()
 
     @Published var snapshot: SystemSnapshot?
+    var isPopoverVisible = false
 
     private var timer: Timer?
+    private var tickCount = 0
     private var cpuCollector = CPUCollector()
     private let memoryCollector = MemoryCollector()
     private var storageCollector = StorageCollector()
@@ -48,8 +50,17 @@ class SystemMonitor: ObservableObject {
         let thermal = thermalCollector.collect(using: smcClient)
         let uptime = ProcessInfo.processInfo.systemUptime
 
-        let topByCPU = processCollector.collectTopByCPU()
-        let topByMemory = processCollector.collectTopByMemory()
+        tickCount += 1
+        let shouldCollectProcesses = isPopoverVisible || tickCount % 3 == 0
+        let topByCPU: [ProcessSnapshot]
+        let topByMemory: [ProcessSnapshot]
+        if shouldCollectProcesses {
+            topByCPU = processCollector.collectTopByCPU()
+            topByMemory = processCollector.collectTopByMemory()
+        } else {
+            topByCPU = snapshot?.cpu.topProcesses ?? []
+            topByMemory = snapshot?.memory.topProcesses ?? []
+        }
 
         let cpuWithProcesses = CPUInfo(
             totalUsage: cpu.totalUsage,

--- a/MacVitals/MacVitals/Utilities/Formatters.swift
+++ b/MacVitals/MacVitals/Utilities/Formatters.swift
@@ -1,27 +1,39 @@
 import Foundation
 
 enum Formatters {
+    nonisolated(unsafe) private static let memoryFormatter: ByteCountFormatter = {
+        let f = ByteCountFormatter()
+        f.countStyle = .memory
+        return f
+    }()
+
+    nonisolated(unsafe) private static let fileFormatter: ByteCountFormatter = {
+        let f = ByteCountFormatter()
+        f.countStyle = .file
+        return f
+    }()
+
+    nonisolated(unsafe) private static let bytesPerSecFormatter: ByteCountFormatter = {
+        let f = ByteCountFormatter()
+        f.countStyle = .memory
+        f.includesUnit = true
+        return f
+    }()
+
     static func percentage(_ value: Double) -> String {
         String(format: "%.0f%%", value)
     }
 
     static func bytes(_ value: UInt64) -> String {
-        let formatter = ByteCountFormatter()
-        formatter.countStyle = .memory
-        return formatter.string(fromByteCount: Int64(value))
+        memoryFormatter.string(fromByteCount: Int64(value))
     }
 
     static func bytesDecimal(_ value: UInt64) -> String {
-        let formatter = ByteCountFormatter()
-        formatter.countStyle = .file
-        return formatter.string(fromByteCount: Int64(value))
+        fileFormatter.string(fromByteCount: Int64(value))
     }
 
     static func bytesPerSecond(_ value: UInt64) -> String {
-        let formatter = ByteCountFormatter()
-        formatter.countStyle = .memory
-        formatter.includesUnit = true
-        return formatter.string(fromByteCount: Int64(value)) + "/s"
+        bytesPerSecFormatter.string(fromByteCount: Int64(value)) + "/s"
     }
 
     static func temperature(_ celsius: Double, unit: TemperatureUnit) -> String {


### PR DESCRIPTION
## Summary
- Cache `ByteCountFormatter` instances as `nonisolated(unsafe) static let` instead of creating new ones per call
- Track popover visibility; skip process enumeration every 3rd tick when popover is hidden
- Reuse previous process data when skipping

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)