### PR TITLE
feat(network): add network monitoring

### DIFF
--- a/MacVitals/MacVitals/Models/NetworkInfo.swift
+++ b/MacVitals/MacVitals/Models/NetworkInfo.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct NetworkInfo {
+    let uploadBytesPerSec: UInt64
+    let downloadBytesPerSec: UInt64
+    let interfaceName: String
+    let ipAddress: String
+
+    static let empty = NetworkInfo(
+        uploadBytesPerSec: 0,
+        downloadBytesPerSec: 0,
+        interfaceName: "",
+        ipAddress: ""
+    )
+}

--- a/MacVitals/MacVitals/Models/SystemSnapshot.swift
+++ b/MacVitals/MacVitals/Models/SystemSnapshot.swift
@@ -7,5 +7,6 @@ struct SystemSnapshot {
     let storage: StorageInfo
     let battery: BatteryInfo?
     let thermal: ThermalInfo
+    let network: NetworkInfo
     let uptime: TimeInterval
 }

--- a/MacVitals/MacVitals/Services/NetworkCollector.swift
+++ b/MacVitals/MacVitals/Services/NetworkCollector.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Darwin
+
+struct NetworkCollector {
+    private var previousUploadBytes: UInt64 = 0
+    private var previousDownloadBytes: UInt64 = 0
+    private var previousTimestamp: Date?
+
+    mutating func collect() -> NetworkInfo {
+        let (interfaceName, ipAddress) = activeInterface()
+        let (uploadBytes, downloadBytes) = totalBytes()
+
+        var uploadPerSec: UInt64 = 0
+        var downloadPerSec: UInt64 = 0
+        let now = Date()
+        if let prev = previousTimestamp {
+            let elapsed = now.timeIntervalSince(prev)
+            if elapsed > 0, uploadBytes >= previousUploadBytes, downloadBytes >= previousDownloadBytes {
+                uploadPerSec = UInt64(Double(uploadBytes - previousUploadBytes) / elapsed)
+                downloadPerSec = UInt64(Double(downloadBytes - previousDownloadBytes) / elapsed)
+            }
+        }
+        previousUploadBytes = uploadBytes
+        previousDownloadBytes = downloadBytes
+        previousTimestamp = now
+
+        return NetworkInfo(
+            uploadBytesPerSec: uploadPerSec,
+            downloadBytesPerSec: downloadPerSec,
+            interfaceName: interfaceName,
+            ipAddress: ipAddress
+        )
+    }
+
+    private func activeInterface() -> (name: String, ip: String) {
+        var ifaddr: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&ifaddr) == 0, let firstAddr = ifaddr else { return ("", "") }
+        defer { freeifaddrs(ifaddr) }
+
+        var bestName = ""
+        var bestIP = ""
+
+        for ptr in sequence(first: firstAddr, next: { $0.pointee.ifa_next }) {
+            let flags = Int32(ptr.pointee.ifa_flags)
+            guard flags & IFF_UP != 0, flags & IFF_RUNNING != 0, flags & IFF_LOOPBACK == 0 else { continue }
+            guard let addr = ptr.pointee.ifa_addr, addr.pointee.sa_family == UInt8(AF_INET) else { continue }
+
+            let name = String(cString: ptr.pointee.ifa_name)
+            var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+            if getnameinfo(addr, socklen_t(addr.pointee.sa_len), &hostname, socklen_t(hostname.count), nil, 0, NI_NUMERICHOST) == 0 {
+                let ip = String(cString: hostname)
+                if name.hasPrefix("en") {
+                    return (name, ip)
+                }
+                if bestName.isEmpty {
+                    bestName = name
+                    bestIP = ip
+                }
+            }
+        }
+        return (bestName, bestIP)
+    }
+
+    private func totalBytes() -> (upload: UInt64, download: UInt64) {
+        var ifaddr: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&ifaddr) == 0, let firstAddr = ifaddr else { return (0, 0) }
+        defer { freeifaddrs(ifaddr) }
+
+        var totalUp: UInt64 = 0
+        var totalDown: UInt64 = 0
+
+        for ptr in sequence(first: firstAddr, next: { $0.pointee.ifa_next }) {
+            let flags = Int32(ptr.pointee.ifa_flags)
+            guard flags & IFF_UP != 0, flags & IFF_LOOPBACK == 0 else { continue }
+            guard let addr = ptr.pointee.ifa_addr, addr.pointee.sa_family == UInt8(AF_LINK) else { continue }
+
+            let data = unsafeBitCast(ptr.pointee.ifa_data, to: UnsafeMutablePointer<if_data>.self)
+            totalUp += UInt64(data.pointee.ifi_obytes)
+            totalDown += UInt64(data.pointee.ifi_ibytes)
+        }
+
+        return (totalUp, totalDown)
+    }
+}

--- a/MacVitals/MacVitals/Services/SystemMonitor.swift
+++ b/MacVitals/MacVitals/Services/SystemMonitor.swift
@@ -14,6 +14,7 @@ class SystemMonitor: ObservableObject {
     private var storageCollector = StorageCollector()
     private let batteryCollector = BatteryCollector()
     private let thermalCollector = ThermalCollector()
+    private var networkCollector = NetworkCollector()
     private var processCollector = ProcessCollector()
     private let smcClient = SMCClient()
 
@@ -49,6 +50,7 @@ class SystemMonitor: ObservableObject {
         let storage = storageCollector.collect()
         let battery = batteryCollector.collect()
         let thermal = thermalCollector.collect(using: smcClient)
+        let network = networkCollector.collect()
         let uptime = ProcessInfo.processInfo.systemUptime
 
         tickCount += 1
@@ -70,6 +72,7 @@ class SystemMonitor: ObservableObject {
             storage: storage,
             battery: battery,
             thermal: thermal,
+            network: network,
             uptime: uptime
         )
     }

--- a/MacVitals/MacVitals/Utilities/UserPreferences.swift
+++ b/MacVitals/MacVitals/Utilities/UserPreferences.swift
@@ -100,6 +100,10 @@ class UserPreferences: ObservableObject {
         didSet { UserDefaults.standard.set(showThermalSection, forKey: "showThermalSection") }
     }
 
+    @Published var showNetworkSection: Bool {
+        didSet { UserDefaults.standard.set(showNetworkSection, forKey: "showNetworkSection") }
+    }
+
     private init() {
         UserDefaults.standard.register(defaults: [
             "showCPUSection": true,
@@ -107,6 +111,7 @@ class UserPreferences: ObservableObject {
             "showStorageSection": true,
             "showBatterySection": true,
             "showThermalSection": true,
+            "showNetworkSection": true,
         ])
 
         self.launchAtLogin = UserDefaults.standard.bool(forKey: "launchAtLogin")
@@ -125,6 +130,7 @@ class UserPreferences: ObservableObject {
         self.showStorageSection = UserDefaults.standard.bool(forKey: "showStorageSection")
         self.showBatterySection = UserDefaults.standard.bool(forKey: "showBatterySection")
         self.showThermalSection = UserDefaults.standard.bool(forKey: "showThermalSection")
+        self.showNetworkSection = UserDefaults.standard.bool(forKey: "showNetworkSection")
     }
 
     private func updateLaunchAtLogin() {

--- a/MacVitals/MacVitals/Views/MenuBarView.swift
+++ b/MacVitals/MacVitals/Views/MenuBarView.swift
@@ -28,6 +28,10 @@ struct MenuBarView: View {
                         BatterySectionView(battery: battery)
                     }
 
+                    if preferences.showNetworkSection {
+                        NetworkSectionView(network: viewModel.snapshot?.network ?? .empty)
+                    }
+
                     if preferences.showThermalSection {
                         ThermalSectionView(thermal: viewModel.snapshot?.thermal ?? .empty)
                     }

--- a/MacVitals/MacVitals/Views/NetworkSectionView.swift
+++ b/MacVitals/MacVitals/Views/NetworkSectionView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct NetworkSectionView: View {
+    let network: NetworkInfo
+
+    var body: some View {
+        DisclosureGroup("Network") {
+            VStack(alignment: .leading, spacing: 8) {
+                if !network.interfaceName.isEmpty {
+                    HStack {
+                        Text(network.interfaceName)
+                            .font(.caption.monospacedDigit())
+                        Spacer()
+                        Text(network.ipAddress)
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                HStack(spacing: 16) {
+                    StatLabel(title: "↓ Download", value: Formatters.bytesPerSecond(network.downloadBytesPerSec))
+                    StatLabel(title: "↑ Upload", value: Formatters.bytesPerSecond(network.uploadBytesPerSec))
+                }
+
+                if network.interfaceName.isEmpty {
+                    Text("No active connection")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.top, 4)
+        }
+    }
+}

--- a/MacVitals/MacVitals/Views/SettingsView.swift
+++ b/MacVitals/MacVitals/Views/SettingsView.swift
@@ -60,6 +60,7 @@ struct DisplaySettingsView: View {
                 Toggle("Memory", isOn: $preferences.showMemorySection)
                 Toggle("Storage", isOn: $preferences.showStorageSection)
                 Toggle("Battery", isOn: $preferences.showBatterySection)
+                Toggle("Network", isOn: $preferences.showNetworkSection)
                 Toggle("Thermals", isOn: $preferences.showThermalSection)
             }
         }


### PR DESCRIPTION
## Summary
- Add `NetworkInfo` model (upload/download bytes/sec, interface name, IP)
- Add `NetworkCollector` using `getifaddrs()` + `if_data` byte counters with delta-based rate calculation
- Add `NetworkSectionView` with download/upload speeds and interface info
- Add `showNetworkSection` toggle to UserPreferences and settings

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)