### PR TITLE
fix(ui): add accessibility labels, colored pressure dot, adaptive grid

### DIFF
--- a/MacVitals/MacVitals/Views/BatterySectionView.swift
+++ b/MacVitals/MacVitals/Views/BatterySectionView.swift
@@ -9,6 +9,8 @@ struct BatterySectionView: View {
                 HStack {
                     Text(Formatters.percentage(battery.level))
                         .font(.caption.monospacedDigit())
+                        .accessibilityLabel("Battery level")
+                        .accessibilityValue(Formatters.percentage(battery.level))
                     if battery.isCharging {
                         Image(systemName: "bolt.fill")
                             .font(.caption)

--- a/MacVitals/MacVitals/Views/CPUSectionView.swift
+++ b/MacVitals/MacVitals/Views/CPUSectionView.swift
@@ -13,7 +13,9 @@ struct CPUSectionView: View {
                 }
 
                 if !cpu.coreUsages.isEmpty {
-                    VStack(spacing: 2) {
+                    let columns = cpu.coreUsages.count > 8 ? 2 : 1
+                    let gridColumns = Array(repeating: GridItem(.flexible(), spacing: 8), count: columns)
+                    LazyVGrid(columns: gridColumns, spacing: 2) {
                         ForEach(Array(cpu.coreUsages.enumerated()), id: \.offset) { index, usage in
                             HStack(spacing: 4) {
                                 Text("\(index)")
@@ -22,6 +24,8 @@ struct CPUSectionView: View {
                                     .frame(width: 20, alignment: .trailing)
                                 ProgressView(value: min(max(usage / 100, 0), 1))
                                     .tint(coreColor(usage))
+                                    .accessibilityLabel("Core \(index)")
+                                    .accessibilityValue(Formatters.percentage(usage))
                                 Text(Formatters.percentage(usage))
                                     .font(.system(size: 9).monospacedDigit())
                                     .foregroundStyle(.secondary)

--- a/MacVitals/MacVitals/Views/MemorySectionView.swift
+++ b/MacVitals/MacVitals/Views/MemorySectionView.swift
@@ -35,13 +35,20 @@ struct PressureBadge: View {
     let pressure: MemoryPressure
 
     var body: some View {
-        Text(pressure.rawValue)
-            .font(.caption2)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(backgroundColor.opacity(0.15))
-            .foregroundStyle(backgroundColor)
-            .clipShape(Capsule())
+        HStack(spacing: 4) {
+            Circle()
+                .fill(backgroundColor)
+                .frame(width: 6, height: 6)
+            Text(pressure.rawValue)
+                .font(.caption2)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(backgroundColor.opacity(0.15))
+        .foregroundStyle(backgroundColor)
+        .clipShape(Capsule())
+        .accessibilityLabel("Memory pressure")
+        .accessibilityValue(pressure.rawValue)
     }
 
     private var backgroundColor: Color {

--- a/MacVitals/MacVitals/Views/OverviewSection.swift
+++ b/MacVitals/MacVitals/Views/OverviewSection.swift
@@ -49,6 +49,8 @@ struct MetricBar: View {
             }
             ProgressView(value: min(max(value, 0), 1))
                 .tint(colorForValue(value))
+                .accessibilityLabel("\(label) usage")
+                .accessibilityValue(displayValue)
         }
     }
 

--- a/MacVitals/MacVitals/Views/StorageSectionView.swift
+++ b/MacVitals/MacVitals/Views/StorageSectionView.swift
@@ -17,6 +17,8 @@ struct StorageSectionView: View {
 
                 ProgressView(value: min(max(storage.usagePercentage / 100, 0), 1))
                     .tint(.forUsage(storage.usagePercentage))
+                    .accessibilityLabel("Storage usage")
+                    .accessibilityValue(Formatters.percentage(storage.usagePercentage))
 
                 HStack(spacing: 16) {
                     StatLabel(title: "Read", value: Formatters.bytesPerSecond(storage.readBytesPerSec))


### PR DESCRIPTION
## Summary
- Add `accessibilityLabel`/`accessibilityValue` to all progress bars and stat values
- Add colored dot indicator to `PressureBadge`
- Use `LazyVGrid` with 2 columns for >8 cores to prevent overly tall layouts

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)