### PR TITLE
feat(gpu): add GPU utilization monitoring

### DIFF
--- a/MacVitals/MacVitals/Models/GPUInfo.swift
+++ b/MacVitals/MacVitals/Models/GPUInfo.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct GPUInfo {
+    let utilizationPercentage: Double
+    let name: String
+
+    static let empty = GPUInfo(utilizationPercentage: 0, name: "")
+}

--- a/MacVitals/MacVitals/Models/SystemSnapshot.swift
+++ b/MacVitals/MacVitals/Models/SystemSnapshot.swift
@@ -8,5 +8,6 @@ struct SystemSnapshot {
     let battery: BatteryInfo?
     let thermal: ThermalInfo
     let network: NetworkInfo
+    let gpu: GPUInfo?
     let uptime: TimeInterval
 }

--- a/MacVitals/MacVitals/Services/GPUCollector.swift
+++ b/MacVitals/MacVitals/Services/GPUCollector.swift
@@ -1,0 +1,37 @@
+import Foundation
+import IOKit
+
+struct GPUCollector {
+    func collect() -> GPUInfo? {
+        let matching = IOServiceMatching("IOAccelerator")
+        var iterator: io_iterator_t = 0
+        guard IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iterator) == KERN_SUCCESS else {
+            return nil
+        }
+        defer { IOObjectRelease(iterator) }
+
+        var service = IOIteratorNext(iterator)
+        while service != 0 {
+            var props: Unmanaged<CFMutableDictionary>?
+            if IORegistryEntryCreateCFProperties(service, &props, kCFAllocatorDefault, 0) == KERN_SUCCESS,
+               let dict = props?.takeRetainedValue() as? [String: Any] {
+                if let perfStats = dict["PerformanceStatistics"] as? [String: Any] {
+                    let utilization = perfStats["Device Utilization %"] as? Int
+                        ?? perfStats["GPU Activity(%)"] as? Int
+                        ?? 0
+                    let name = dict["model"] as? String
+                        ?? dict["IOClass"] as? String
+                        ?? "GPU"
+                    IOObjectRelease(service)
+                    return GPUInfo(
+                        utilizationPercentage: Double(utilization),
+                        name: name
+                    )
+                }
+            }
+            IOObjectRelease(service)
+            service = IOIteratorNext(iterator)
+        }
+        return nil
+    }
+}

--- a/MacVitals/MacVitals/Services/SystemMonitor.swift
+++ b/MacVitals/MacVitals/Services/SystemMonitor.swift
@@ -17,6 +17,7 @@ class SystemMonitor: ObservableObject {
     private let batteryCollector = BatteryCollector()
     private let thermalCollector = ThermalCollector()
     private var networkCollector = NetworkCollector()
+    private let gpuCollector = GPUCollector()
     private var processCollector = ProcessCollector()
     private let smcClient = SMCClient()
 
@@ -55,6 +56,7 @@ class SystemMonitor: ObservableObject {
         let battery = batteryCollector.collect()
         let thermal = thermalCollector.collect(using: smcClient)
         let network = networkCollector.collect()
+        let gpu = gpuCollector.collect()
         let uptime = ProcessInfo.processInfo.systemUptime
 
         tickCount += 1
@@ -78,6 +80,7 @@ class SystemMonitor: ObservableObject {
             battery: battery,
             thermal: thermal,
             network: network,
+            gpu: gpu,
             uptime: uptime
         )
     }

--- a/MacVitals/MacVitals/Views/GPUSectionView.swift
+++ b/MacVitals/MacVitals/Views/GPUSectionView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct GPUSectionView: View {
+    let gpu: GPUInfo
+
+    var body: some View {
+        DisclosureGroup("GPU") {
+            VStack(alignment: .leading, spacing: 8) {
+                if !gpu.name.isEmpty {
+                    Text(gpu.name)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                HStack {
+                    Text("Utilization")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text(Formatters.percentage(gpu.utilizationPercentage))
+                        .font(.caption.monospacedDigit())
+                }
+
+                ProgressView(value: min(max(gpu.utilizationPercentage / 100, 0), 1))
+                    .tint(gpu.utilizationPercentage > 90 ? .red : gpu.utilizationPercentage > 70 ? .orange : .accentColor)
+                    .accessibilityLabel("GPU utilization")
+                    .accessibilityValue(Formatters.percentage(gpu.utilizationPercentage))
+            }
+            .padding(.top, 4)
+        }
+    }
+}

--- a/MacVitals/MacVitals/Views/MenuBarView.swift
+++ b/MacVitals/MacVitals/Views/MenuBarView.swift
@@ -32,6 +32,10 @@ struct MenuBarView: View {
                         NetworkSectionView(network: viewModel.snapshot?.network ?? .empty)
                     }
 
+                    if let gpu = viewModel.snapshot?.gpu {
+                        GPUSectionView(gpu: gpu)
+                    }
+
                     if preferences.showThermalSection {
                         ThermalSectionView(thermal: viewModel.snapshot?.thermal ?? .empty)
                     }


### PR DESCRIPTION
## Summary
- Add `GPUInfo` model with utilization percentage and GPU name
- Add `GPUCollector` using `IOAccelerator` IOKit class for Apple Silicon GPU stats
- Add `GPUSectionView` with utilization bar and GPU name display

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)