### PR TITLE
feat(ui): add history sparklines for CPU and memory

### DIFF
--- a/MacVitals/MacVitals/Services/SystemMonitor.swift
+++ b/MacVitals/MacVitals/Services/SystemMonitor.swift
@@ -6,6 +6,9 @@ class SystemMonitor: ObservableObject {
 
     @Published var snapshot: SystemSnapshot?
     var isPopoverVisible = false
+    @Published var cpuHistory: [Double] = []
+    @Published var memoryHistory: [Double] = []
+    private let maxHistorySize = 60
 
     private var timer: Timer?
     private var tickCount = 0
@@ -62,6 +65,11 @@ class SystemMonitor: ObservableObject {
             topByCPU = snapshot?.cpu.topProcesses ?? []
             topByMemory = snapshot?.memory.topProcesses ?? []
         }
+
+        cpuHistory.append(cpu.totalUsage)
+        if cpuHistory.count > maxHistorySize { cpuHistory.removeFirst() }
+        memoryHistory.append(memory.usagePercentage)
+        if memoryHistory.count > maxHistorySize { memoryHistory.removeFirst() }
 
         snapshot = SystemSnapshot(
             timestamp: Date(),

--- a/MacVitals/MacVitals/Views/MenuBarView.swift
+++ b/MacVitals/MacVitals/Views/MenuBarView.swift
@@ -10,7 +10,11 @@ struct MenuBarView: View {
             Divider()
             ScrollView {
                 VStack(spacing: 12) {
-                    OverviewSection(snapshot: viewModel.snapshot)
+                    OverviewSection(
+                        snapshot: viewModel.snapshot,
+                        cpuHistory: SystemMonitor.shared.cpuHistory,
+                        memoryHistory: SystemMonitor.shared.memoryHistory
+                    )
 
                     if preferences.showCPUSection {
                         CPUSectionView(cpu: viewModel.snapshot?.cpu ?? .empty)

--- a/MacVitals/MacVitals/Views/OverviewSection.swift
+++ b/MacVitals/MacVitals/Views/OverviewSection.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct OverviewSection: View {
     let snapshot: SystemSnapshot?
+    var cpuHistory: [Double] = []
+    var memoryHistory: [Double] = []
 
     var body: some View {
         VStack(spacing: 8) {
@@ -22,6 +24,25 @@ struct OverviewSection: View {
                         value: snapshot.memory.usagePercentage / 100,
                         displayValue: Formatters.percentage(snapshot.memory.usagePercentage)
                     )
+                }
+
+                if !cpuHistory.isEmpty || !memoryHistory.isEmpty {
+                    HStack(spacing: 16) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("CPU")
+                                .font(.system(size: 9))
+                                .foregroundStyle(.tertiary)
+                            SparklineView(data: cpuHistory, color: .blue)
+                                .frame(height: 24)
+                        }
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Memory")
+                                .font(.system(size: 9))
+                                .foregroundStyle(.tertiary)
+                            SparklineView(data: memoryHistory, color: .green)
+                                .frame(height: 24)
+                        }
+                    }
                 }
             } else {
                 Text("Loading...")

--- a/MacVitals/MacVitals/Views/SparklineView.swift
+++ b/MacVitals/MacVitals/Views/SparklineView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct SparklineView: View {
+    let data: [Double]
+    let maxValue: Double
+    let color: Color
+
+    init(data: [Double], maxValue: Double = 100, color: Color = .accentColor) {
+        self.data = data
+        self.maxValue = maxValue
+        self.color = color
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            if data.count > 1 {
+                Path { path in
+                    let width = geometry.size.width
+                    let height = geometry.size.height
+                    let stepX = width / CGFloat(max(data.count - 1, 1))
+
+                    for (index, value) in data.enumerated() {
+                        let x = CGFloat(index) * stepX
+                        let normalized = min(max(value / maxValue, 0), 1)
+                        let y = height - (CGFloat(normalized) * height)
+                        if index == 0 {
+                            path.move(to: CGPoint(x: x, y: y))
+                        } else {
+                            path.addLine(to: CGPoint(x: x, y: y))
+                        }
+                    }
+                }
+                .stroke(color, lineWidth: 1.5)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Store rolling 60-sample history buffers for CPU and memory in SystemMonitor
- Add `SparklineView` using SwiftUI `Path` drawing (lightweight, no Charts dependency)
- Display inline CPU/memory sparklines in OverviewSection

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)