### PR TITLE
chore: add global hotkey, update check, and onboarding hint

### DIFF
--- a/MacVitals/MacVitals/AppDelegate.swift
+++ b/MacVitals/MacVitals/AppDelegate.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import AppKit
 import Combine
+import Carbon.HIToolbox
 
 @MainActor
 class AppDelegate: NSObject, NSApplicationDelegate {
@@ -34,6 +35,23 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.setActivationPolicy(.accessory)
 
         SystemMonitor.shared.start()
+
+        NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            if event.modifierFlags.contains([.option, .shift]) && event.keyCode == 9 {
+                Task { @MainActor in
+                    self?.togglePopover()
+                }
+            }
+        }
+        NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            if event.modifierFlags.contains([.option, .shift]) && event.keyCode == 9 {
+                Task { @MainActor in
+                    self?.togglePopover()
+                }
+                return nil
+            }
+            return event
+        }
 
         cancellable = SystemMonitor.shared.$snapshot.map { _ in () }
             .merge(with: UserPreferences.shared.$menuBarDisplayMode.map { _ in () })

--- a/MacVitals/MacVitals/Views/SettingsView.swift
+++ b/MacVitals/MacVitals/Views/SettingsView.swift
@@ -90,6 +90,18 @@ struct AboutSettingsView: View {
                 Constants.openGitHub()
             }
 
+            Button("Check for Updates") {
+                if let url = URL(string: Constants.githubURL + "/releases/latest") {
+                    NSWorkspace.shared.open(url)
+                }
+            }
+            .buttonStyle(.link)
+            .font(.caption)
+
+            Text("Tip: Press ⌥⇧V to toggle the popover")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+
             Spacer()
         }
         .frame(maxWidth: .infinity)


### PR DESCRIPTION
## Summary
- Add ⌥⇧V global keyboard shortcut to toggle popover
- Add "Check for Updates" link to GitHub releases in About tab
- Show keyboard shortcut tip in settings for discoverability

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)