### PR TITLE
fix(popover): metrics not updating on refresh interval

### DIFF
--- a/MacVitals/ViewModels/MenuBarViewModel.swift
+++ b/MacVitals/ViewModels/MenuBarViewModel.swift
@@ -1,9 +1,0 @@
-import Foundation
-
-@MainActor
-@Observable
-class MenuBarViewModel {
-    var snapshot: SystemSnapshot? {
-        SystemMonitor.shared.snapshot
-    }
-}

--- a/MacVitals/Views/MenuBarView.swift
+++ b/MacVitals/Views/MenuBarView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct MenuBarView: View {
-    @State private var viewModel = MenuBarViewModel()
+    @ObservedObject private var monitor = SystemMonitor.shared
     @EnvironmentObject var preferences: UserPreferences
 
     var body: some View {
@@ -11,37 +11,37 @@ struct MenuBarView: View {
             ScrollView {
                 VStack(spacing: 12) {
                     OverviewSection(
-                        snapshot: viewModel.snapshot,
-                        cpuHistory: SystemMonitor.shared.cpuHistory,
-                        memoryHistory: SystemMonitor.shared.memoryHistory
+                        snapshot: monitor.snapshot,
+                        cpuHistory: monitor.cpuHistory,
+                        memoryHistory: monitor.memoryHistory
                     )
 
                     if preferences.showCPUSection {
-                        CPUSectionView(cpu: viewModel.snapshot?.cpu ?? .empty)
+                        CPUSectionView(cpu: monitor.snapshot?.cpu ?? .empty)
                     }
 
                     if preferences.showMemorySection {
-                        MemorySectionView(memory: viewModel.snapshot?.memory ?? .empty)
+                        MemorySectionView(memory: monitor.snapshot?.memory ?? .empty)
                     }
 
                     if preferences.showStorageSection {
-                        StorageSectionView(storage: viewModel.snapshot?.storage ?? .empty)
+                        StorageSectionView(storage: monitor.snapshot?.storage ?? .empty)
                     }
 
-                    if preferences.showBatterySection, let battery = viewModel.snapshot?.battery {
+                    if preferences.showBatterySection, let battery = monitor.snapshot?.battery {
                         BatterySectionView(battery: battery)
                     }
 
                     if preferences.showNetworkSection {
-                        NetworkSectionView(network: viewModel.snapshot?.network ?? .empty)
+                        NetworkSectionView(network: monitor.snapshot?.network ?? .empty)
                     }
 
-                    if let gpu = viewModel.snapshot?.gpu {
+                    if let gpu = monitor.snapshot?.gpu {
                         GPUSectionView(gpu: gpu)
                     }
 
                     if preferences.showThermalSection {
-                        ThermalSectionView(thermal: viewModel.snapshot?.thermal ?? .empty)
+                        ThermalSectionView(thermal: monitor.snapshot?.thermal ?? .empty)
                     }
                 }
                 .padding(16)


### PR DESCRIPTION
## Summary
- Removed `MenuBarViewModel` (pass-through with computed property that `@Observable` couldn't track)
- `MenuBarView` now observes `SystemMonitor.shared` directly via `@ObservedObject`, so the popover re-renders on every timer tick

Closes #73

## Test plan
- [ ] Open popover and verify CPU, Memory, Storage, Battery, Network, GPU, Thermals update every refresh interval
- [ ] Change refresh rate in settings and confirm popover updates at the new interval
- [ ] Verify menu bar status item still updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)