### PR TITLE
feat(ui): show all sections expanded by default

### DIFF
--- a/MacVitals/Views/BatterySectionView.swift
+++ b/MacVitals/Views/BatterySectionView.swift
@@ -4,7 +4,9 @@ struct BatterySectionView: View {
     let battery: BatteryInfo
 
     var body: some View {
-        DisclosureGroup("Battery") {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Battery")
+                .font(.headline)
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
                     Text(Formatters.percentage(battery.level))
@@ -35,7 +37,6 @@ struct BatterySectionView: View {
                     }
                 }
             }
-            .padding(.top, 4)
         }
     }
 }

--- a/MacVitals/Views/CPUSectionView.swift
+++ b/MacVitals/Views/CPUSectionView.swift
@@ -4,7 +4,9 @@ struct CPUSectionView: View {
     let cpu: CPUInfo
 
     var body: some View {
-        DisclosureGroup("CPU") {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("CPU")
+                .font(.headline)
             VStack(alignment: .leading, spacing: 8) {
                 HStack(spacing: 16) {
                     StatLabel(title: "Total", value: Formatters.percentage(cpu.totalUsage))
@@ -42,7 +44,6 @@ struct CPUSectionView: View {
                         .lineLimit(1)
                 }
             }
-            .padding(.top, 4)
         }
     }
 

--- a/MacVitals/Views/GPUSectionView.swift
+++ b/MacVitals/Views/GPUSectionView.swift
@@ -4,7 +4,9 @@ struct GPUSectionView: View {
     let gpu: GPUInfo
 
     var body: some View {
-        DisclosureGroup("GPU") {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("GPU")
+                .font(.headline)
             VStack(alignment: .leading, spacing: 8) {
                 if !gpu.name.isEmpty {
                     Text(gpu.name)
@@ -26,7 +28,6 @@ struct GPUSectionView: View {
                     .accessibilityLabel("GPU utilization")
                     .accessibilityValue(Formatters.percentage(gpu.utilizationPercentage))
             }
-            .padding(.top, 4)
         }
     }
 }

--- a/MacVitals/Views/MemorySectionView.swift
+++ b/MacVitals/Views/MemorySectionView.swift
@@ -4,7 +4,9 @@ struct MemorySectionView: View {
     let memory: MemoryInfo
 
     var body: some View {
-        DisclosureGroup("Memory") {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Memory")
+                .font(.headline)
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
                     Text("\(Formatters.bytes(memory.used)) / \(Formatters.bytes(memory.total))")
@@ -26,7 +28,6 @@ struct MemorySectionView: View {
                         .lineLimit(1)
                 }
             }
-            .padding(.top, 4)
         }
     }
 }

--- a/MacVitals/Views/NetworkSectionView.swift
+++ b/MacVitals/Views/NetworkSectionView.swift
@@ -4,7 +4,9 @@ struct NetworkSectionView: View {
     let network: NetworkInfo
 
     var body: some View {
-        DisclosureGroup("Network") {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Network")
+                .font(.headline)
             VStack(alignment: .leading, spacing: 8) {
                 if !network.interfaceName.isEmpty {
                     HStack {
@@ -28,7 +30,6 @@ struct NetworkSectionView: View {
                         .foregroundStyle(.secondary)
                 }
             }
-            .padding(.top, 4)
         }
     }
 }

--- a/MacVitals/Views/StorageSectionView.swift
+++ b/MacVitals/Views/StorageSectionView.swift
@@ -4,7 +4,9 @@ struct StorageSectionView: View {
     let storage: StorageInfo
 
     var body: some View {
-        DisclosureGroup("Storage") {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Storage")
+                .font(.headline)
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
                     Text("\(Formatters.bytesDecimal(storage.used)) / \(Formatters.bytesDecimal(storage.total))")
@@ -25,7 +27,6 @@ struct StorageSectionView: View {
                     StatLabel(title: "Write", value: Formatters.bytesPerSecond(storage.writeBytesPerSec))
                 }
             }
-            .padding(.top, 4)
         }
     }
 }

--- a/MacVitals/Views/ThermalSectionView.swift
+++ b/MacVitals/Views/ThermalSectionView.swift
@@ -5,7 +5,9 @@ struct ThermalSectionView: View {
     @EnvironmentObject var preferences: UserPreferences
 
     var body: some View {
-        DisclosureGroup("Thermals") {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Thermals")
+                .font(.headline)
             VStack(alignment: .leading, spacing: 8) {
                 if thermal.cpuTemperature != nil || thermal.gpuTemperature != nil {
                     HStack(spacing: 16) {
@@ -47,7 +49,6 @@ struct ThermalSectionView: View {
                         .foregroundStyle(.secondary)
                 }
             }
-            .padding(.top, 4)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replaced `DisclosureGroup` with static section headers across all 7 section views
- All stats (CPU, Memory, Storage, Battery, Network, GPU, Thermals) are now visible at once without toggling

Closes #75

## Test plan
- [ ] Open popover and verify all sections are expanded and visible
- [ ] Scroll through to confirm all section content renders correctly
- [ ] Verify no visual regressions in section layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)