### PR TITLE
fix(thermal): expand SMC keys for Apple Silicon

### DIFF
--- a/MacVitals/Services/SMCClient.swift
+++ b/MacVitals/Services/SMCClient.swift
@@ -124,7 +124,10 @@ class SMCClient {
             &outputSize
         )
 
-        guard result == KERN_SUCCESS else { return nil }
+        guard result == KERN_SUCCESS else {
+            Self.logger.debug("readKey failed for '\(key)' with result: \(result)")
+            return nil
+        }
 
         return withUnsafeBytes(of: outputStruct.bytes) {
             Array($0.prefix(Int(dataSize)))

--- a/MacVitals/Services/SystemMonitor.swift
+++ b/MacVitals/Services/SystemMonitor.swift
@@ -29,7 +29,9 @@ class SystemMonitor: ObservableObject {
     func start() {
         logger.info("Starting system monitor")
         stop()
-        _ = smcClient.open()
+        if !smcClient.open() {
+            logger.warning("Failed to open SMC connection — thermal data will be unavailable")
+        }
 
         let interval = UserPreferences.shared.refreshRate.rawValue
         timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in

--- a/MacVitals/Services/ThermalCollector.swift
+++ b/MacVitals/Services/ThermalCollector.swift
@@ -1,17 +1,40 @@
 import Foundation
+import os.log
 
 struct ThermalCollector {
-    private let cpuTempKeys = ["TC0P", "Tp09", "Tp01", "TC0p"]
-    private let gpuTempKeys = ["TG0P", "Tg05", "Tg0P"]
+    private static let logger = Logger(subsystem: "com.macvitals.app", category: "ThermalCollector")
+
+    // Intel + Apple Silicon CPU temperature keys
+    private let cpuTempKeys = [
+        "TC0P", "TC0p",             // Intel: CPU proximity
+        "TC0c", "TC1c",             // Intel: per-core
+        "Tp09", "Tp01", "Tp05",     // Apple Silicon: CPU die sensors
+        "Tp0D", "Tp0A", "Tp0F",     // Apple Silicon: efficiency/performance cores
+    ]
+
+    // Intel + Apple Silicon GPU temperature keys
+    private let gpuTempKeys = [
+        "TG0P", "Tg0P",             // Intel: GPU proximity
+        "Tg05", "Tg0D", "Tg0J",     // Apple Silicon: GPU die sensors
+        "Tg1d",                      // Apple Silicon: additional GPU sensor
+    ]
 
     func collect(using smc: SMCClient) -> ThermalInfo {
         let cpuTemp = cpuTempKeys.lazy
             .compactMap { smc.readTemperature(key: $0) }
             .first { $0 > 0 && $0 < 150 }
 
+        if cpuTemp == nil {
+            Self.logger.warning("No CPU temperature found from keys: \(self.cpuTempKeys)")
+        }
+
         let gpuTemp = gpuTempKeys.lazy
             .compactMap { smc.readTemperature(key: $0) }
             .first { $0 > 0 && $0 < 150 }
+
+        if gpuTemp == nil {
+            Self.logger.debug("No GPU temperature found from keys: \(self.gpuTempKeys)")
+        }
 
         let fanCount = smc.readFanCount()
         var fans: [FanInfo] = []


### PR DESCRIPTION
## Summary
- Expanded CPU temperature SMC keys to cover Apple Silicon (M1-M4) alongside Intel
- Expanded GPU temperature SMC keys for Apple Silicon
- Added logging to `ThermalCollector`, `SMCClient.readKey()`, and `SystemMonitor.start()` to diagnose SMC failures
- `smcClient.open()` result is now checked and logged instead of discarded

Closes #74

## Test plan
- [ ] Run on Apple Silicon Mac and verify Thermals section shows CPU temperature
- [ ] Check Console.app for `ThermalCollector`/`SMCClient` log messages
- [ ] Verify no regression on Intel Macs (if available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)