### PR TITLE
feat(export): CSV performance data recording + export

### DIFF
--- a/MacVitals/Services/DataRecorder.swift
+++ b/MacVitals/Services/DataRecorder.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+@MainActor
+class DataRecorder {
+    static let shared = DataRecorder()
+
+    private var buffer: [SystemSnapshot] = []
+    private let maxDuration: TimeInterval = 3600
+
+    private init() {}
+
+    func record(_ snapshot: SystemSnapshot) {
+        buffer.append(snapshot)
+        let cutoff = Date().addingTimeInterval(-maxDuration)
+        buffer.removeAll { $0.timestamp < cutoff }
+    }
+
+    var snapshotCount: Int { buffer.count }
+
+    func exportCSV(lastMinutes: Int) -> URL? {
+        let cutoff = Date().addingTimeInterval(-Double(lastMinutes * 60))
+        let filtered = buffer.filter { $0.timestamp >= cutoff }
+        guard !filtered.isEmpty else { return nil }
+
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        var csv = "timestamp,cpu_percent,memory_percent,disk_read_bytes_sec,disk_write_bytes_sec,net_download_bytes_sec,net_upload_bytes_sec,cpu_temp_c,gpu_temp_c,battery_percent\n"
+
+        for snap in filtered {
+            let ts = dateFormatter.string(from: snap.timestamp)
+            let cpu = String(format: "%.1f", snap.cpu.totalUsage)
+            let mem = String(format: "%.1f", snap.memory.usagePercentage)
+            let diskR = "\(snap.storage.readBytesPerSec)"
+            let diskW = "\(snap.storage.writeBytesPerSec)"
+            let netD = "\(snap.network.downloadBytesPerSec)"
+            let netU = "\(snap.network.uploadBytesPerSec)"
+            let cpuTemp = snap.thermal.cpuTemperature.map { String(format: "%.1f", $0) } ?? ""
+            let gpuTemp = snap.thermal.gpuTemperature.map { String(format: "%.1f", $0) } ?? ""
+            let battery = snap.battery.map { String(format: "%.0f", $0.level) } ?? ""
+
+            csv += "\(ts),\(cpu),\(mem),\(diskR),\(diskW),\(netD),\(netU),\(cpuTemp),\(gpuTemp),\(battery)\n"
+        }
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let fileName = "MacVitals_\(Int(Date().timeIntervalSince1970)).csv"
+        let fileURL = tempDir.appendingPathComponent(fileName)
+
+        do {
+            try csv.write(to: fileURL, atomically: true, encoding: .utf8)
+            return fileURL
+        } catch {
+            return nil
+        }
+    }
+}

--- a/MacVitals/Services/SystemMonitor.swift
+++ b/MacVitals/Services/SystemMonitor.swift
@@ -109,6 +109,7 @@ class SystemMonitor: ObservableObject {
             uptime: uptime
         )
         snapshot = newSnapshot
+        DataRecorder.shared.record(newSnapshot)
         if timer != nil {
             AlertManager.shared.evaluate(snapshot: newSnapshot)
         }

--- a/MacVitals/Views/ExportView.swift
+++ b/MacVitals/Views/ExportView.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+import AppKit
+
+enum ExportDuration: Int, CaseIterable, Identifiable {
+    case fiveMinutes = 5
+    case fifteenMinutes = 15
+    case oneHour = 60
+
+    var id: Int { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .fiveMinutes: return "Last 5 min"
+        case .fifteenMinutes: return "Last 15 min"
+        case .oneHour: return "Last 1 hour"
+        }
+    }
+}
+
+struct ExportView: View {
+    @State private var selectedDuration: ExportDuration = .fifteenMinutes
+    @State private var exportStatus: String?
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("Export Performance Data")
+                .font(.headline)
+
+            Text("\(DataRecorder.shared.snapshotCount) snapshots recorded")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Picker("Duration", selection: $selectedDuration) {
+                ForEach(ExportDuration.allCases) { duration in
+                    Text(duration.displayName).tag(duration)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            if let status = exportStatus {
+                Text(status)
+                    .font(.caption)
+                    .foregroundStyle(status.contains("Error") ? .red : .green)
+            }
+
+            HStack {
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+
+                Button("Export CSV") { exportCSV() }
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(20)
+        .frame(width: 320)
+    }
+
+    private func exportCSV() {
+        guard let fileURL = DataRecorder.shared.exportCSV(lastMinutes: selectedDuration.rawValue) else {
+            exportStatus = "Error: no data for selected period"
+            return
+        }
+
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.commaSeparatedText]
+        panel.nameFieldStringValue = fileURL.lastPathComponent
+        panel.canCreateDirectories = true
+
+        if panel.runModal() == .OK, let dest = panel.url {
+            do {
+                if FileManager.default.fileExists(atPath: dest.path) {
+                    try FileManager.default.removeItem(at: dest)
+                }
+                try FileManager.default.copyItem(at: fileURL, to: dest)
+                exportStatus = "Exported successfully"
+            } catch {
+                exportStatus = "Error: \(error.localizedDescription)"
+            }
+        }
+    }
+}

--- a/MacVitals/Views/SettingsView.swift
+++ b/MacVitals/Views/SettingsView.swift
@@ -14,6 +14,9 @@ struct SettingsView: View {
             NotificationSettingsView()
                 .tabItem { Label("Notifications", systemImage: "bell") }
 
+            DataSettingsView()
+                .tabItem { Label("Data", systemImage: "square.and.arrow.up") }
+
             AboutSettingsView()
                 .tabItem { Label("About", systemImage: "info.circle") }
         }
@@ -120,6 +123,37 @@ struct NotificationSettingsView: View {
             }
         }
         .formStyle(.grouped)
+    }
+}
+
+struct DataSettingsView: View {
+    @State private var showExport = false
+
+    var body: some View {
+        Form {
+            Section("Recording") {
+                HStack {
+                    Text("Snapshots in buffer")
+                    Spacer()
+                    Text("\(DataRecorder.shared.snapshotCount)")
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                }
+                Text("Up to 1 hour of data is kept in memory")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Export") {
+                Button("Export to CSV...") {
+                    showExport = true
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .sheet(isPresented: $showExport) {
+            ExportView()
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- **DataRecorder**: Ring buffer storing up to 1 hour of `SystemSnapshot`s. `exportCSV(lastMinutes:)` writes ISO 8601 timestamp, CPU%, memory%, disk read/write bytes/sec, network download/upload bytes/sec, CPU/GPU temperatures, and battery % to a temp CSV file
- **ExportView**: Sheet with duration picker (5min/15min/1hr), snapshot count display, and export button that opens NSSavePanel
- **SystemMonitor**: Feeds each snapshot to `DataRecorder.shared.record()`
- **Settings > Data tab**: Shows buffer snapshot count and "Export to CSV..." button

## Test plan
- [x] `xcodebuild build` succeeds
- [x] All 22 unit tests pass
- [ ] Wait ~1 min for data, open Settings > Data, verify snapshot count > 0
- [ ] Click "Export to CSV...", select 5 min duration, export
- [ ] Open CSV in text editor, verify headers and data rows

> **Note:** Based on `feature/84-section-reordering-alert-config` (#91). Merge #91 first.

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)