### PR TITLE
fix(perf): replace unbounded ProcessIconCache with NSCache

### DIFF
--- a/MacVitals/Utilities/ProcessIconCache.swift
+++ b/MacVitals/Utilities/ProcessIconCache.swift
@@ -3,12 +3,17 @@ import AppKit
 @MainActor
 final class ProcessIconCache {
     static let shared = ProcessIconCache()
-    private var cache: [String: NSImage] = [:]
+    private let cache: NSCache<NSString, NSImage> = {
+        let cache = NSCache<NSString, NSImage>()
+        cache.countLimit = 200
+        return cache
+    }()
 
     func icon(for process: ProcessSnapshot) -> NSImage {
-        if let cached = cache[process.executablePath] { return cached }
+        let key = process.executablePath as NSString
+        if let cached = cache.object(forKey: key) { return cached }
         let image = resolveIcon(path: process.executablePath)
-        cache[process.executablePath] = image
+        cache.setObject(image, forKey: key)
         return image
     }
 


### PR DESCRIPTION
## Summary
- Replace plain `[String: NSImage]` dictionary in `ProcessIconCache` with `NSCache<NSString, NSImage>` (count limit 200)
- Prevents unbounded memory growth in long-running menu bar app as stale process icon entries are now auto-evicted under memory pressure

Closes #99

## Test plan
- [ ] Verify process icons still display correctly in CPU, Memory, and Processes views
- [ ] Monitor memory usage over extended runtime — stale entries should be evicted

🤖 Generated with [Claude Code](https://claude.com/claude-code)