### PR TITLE
feat(theme): align UI color scheme with app icon

### DIFF
--- a/MacVitals/Theme/Theme.swift
+++ b/MacVitals/Theme/Theme.swift
@@ -3,14 +3,14 @@ import SwiftUI
 enum Theme {
 
     enum Colors {
-        static let backgroundDark = Color(red: 0.02, green: 0.02, blue: 0.05)
-        static let backgroundNavy = Color(red: 0.06, green: 0.07, blue: 0.14)
+        static let backgroundDark = Color(red: 0.04, green: 0.02, blue: 0.01)
+        static let backgroundNavy = Color(red: 0.09, green: 0.05, blue: 0.03)
         static let cardBackground = Color.white.opacity(0.05)
         static let cardBorder = Color.white.opacity(0.08)
 
-        static let accentCyan = Color(red: 0.0, green: 0.8, blue: 0.9)
-        static let warningOrange = Color.orange
-        static let criticalRed = Color.red
+        static let accentCyan = Color(red: 0.82, green: 0.52, blue: 0.08)
+        static let warningOrange = Color(red: 0.90, green: 0.38, blue: 0.08)
+        static let criticalRed = Color(red: 0.78, green: 0.12, blue: 0.06)
         static let nominalGreen = Color.green
 
         static let textPrimary = Color.white
@@ -34,9 +34,9 @@ enum Theme {
 
         static let statusBar = LinearGradient(
             colors: [
-                Color(red: 0.0, green: 0.8, blue: 0.9),
-                Color(red: 0.5, green: 0.2, blue: 0.8),
-                Color(red: 0.9, green: 0.2, blue: 0.3),
+                Color(red: 0.82, green: 0.60, blue: 0.08),
+                Color(red: 0.80, green: 0.32, blue: 0.08),
+                Color(red: 0.75, green: 0.12, blue: 0.06),
             ],
             startPoint: .leading,
             endPoint: .trailing

--- a/MacVitals/Views/Components/RingGaugeView.swift
+++ b/MacVitals/Views/Components/RingGaugeView.swift
@@ -66,7 +66,10 @@ enum RingGradients {
     }
 
     static let cpu = AngularGradient(
-        colors: [Theme.Colors.accentCyan.opacity(0.3), Theme.Colors.accentCyan],
+        colors: [
+            Color(red: 0.82, green: 0.60, blue: 0.08).opacity(0.3),
+            Color(red: 0.75, green: 0.12, blue: 0.06),
+        ],
         center: .center,
         startAngle: .degrees(-90),
         endAngle: .degrees(270)


### PR DESCRIPTION
## Summary

The app UI previously used a blue-navy background with a cyan primary accent, which clashed with the icon's warm dark aesthetic. This PR realigns the color palette to match the icon — a near-black background with a gold → amber → deep-red gradient arc.

## Changes

- **`MacVitals/Theme/Theme.swift`**
  - Replace blue-tinted backgrounds (`backgroundDark`, `backgroundNavy`) with near-black warm-tinted values
  - Change `accentCyan` from cyan to amber/gold `(0.82, 0.52, 0.08)` — matching the icon's gauge start color
  - Tighten `warningOrange` to a warm orange `(0.90, 0.38, 0.08)`
  - Replace `criticalRed` (`Color.red`) with the icon's deep warm red `(0.78, 0.12, 0.06)`
  - Update `statusBar` gradient from cyan → purple → red to gold → amber → deep-red
- **`MacVitals/Views/Components/RingGaugeView.swift`**
  - Update `RingGradients.cpu` to arc from gold to deep-red, mirroring the icon's circular gauge

## Additional Notes

All 19 view files inherit the changes automatically via `Theme.Colors.*` tokens — no individual view edits required.

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)